### PR TITLE
Ajusta linguagem acadêmica nas telas do aluno

### DIFF
--- a/app/(dashboard)/aluno/_components/AlunoTopbar.tsx
+++ b/app/(dashboard)/aluno/_components/AlunoTopbar.tsx
@@ -115,7 +115,7 @@ export default function AlunoTopbar({
           )}
         </h1>
         <p className="text-muted-foreground">
-          Encontre respostas rápidas ou abra um chamado se precisar de ajuda.
+          Encontre respostas rápidas ou abra uma solicitação acadêmica se precisar de ajuda.
         </p>
       </div>
 

--- a/app/(dashboard)/aluno/_components/SidebarAluno.tsx
+++ b/app/(dashboard)/aluno/_components/SidebarAluno.tsx
@@ -39,7 +39,7 @@ export default function SidebarAluno({
 
   const items: NavItemProps[] = [
     { href: "/aluno/home", label: "Visão Geral", icon: <LayoutDashboard className="size-4" /> },
-    { href: "/aluno/chamados", label: "Meus chamados", icon: <Ticket className="size-4" />},
+    { href: "/aluno/chamados", label: "Minhas solicitações", icon: <Ticket className="size-4" />},
     { href: "/aluno/catalogo", label: "Catálogo de serviços", icon: <BookOpen className="size-4" /> },
     { href: "/aluno/dados", label: "Meus dados", icon: <User className="size-4" /> },
     { href: "/aluno/notificacoes", label: "Notificações", icon: <Bell className="size-4" /> },
@@ -118,11 +118,11 @@ export default function SidebarAluno({
           <div className="text-xs text-muted-foreground mb-2">Indicadores rápidos</div>
           <ul className="space-y-2 text-sm">
             <li className="flex items-center justify-between">
-              <span>Aguardando você</span>
+              <span>Aguardando resposta</span>
               <span className="font-medium">{aguardandoCount}</span>
             </li>
             <li className="flex items-center justify-between">
-              <span>Meus chamados</span>
+              <span>Minhas solicitações</span>
               <span className="font-medium">{meusChamadosCount}</span>
             </li>
           </ul>

--- a/app/(dashboard)/aluno/ajuda/page.tsx
+++ b/app/(dashboard)/aluno/ajuda/page.tsx
@@ -36,18 +36,18 @@ const FAQS: FAQ[] = [
     categoria: "Acadêmico",
     pergunta: "Como peço revisão de nota?",
     resposta:
-      "Acesse Catálogo → Secretaria → ‘Revisão de nota’. Abra um chamado com a disciplina, avaliação e justificativa. Anexe documentos se necessário.",
-    links: [{ label: "Abrir chamado (Revisão de nota)", href: "/aluno/novo-chamado?servicoId=revisao-nota" }],
+      "Acesse Catálogo → Secretaria → ‘Revisão de nota’. Abra uma solicitação acadêmica com a disciplina, avaliação e justificativa. Anexe documentos se necessário.",
+    links: [{ label: "Abrir solicitação acadêmica (Revisão de nota)", href: "/aluno/novo-chamado?servicoId=revisao-nota" }],
   },
   {
     id: "faq-4",
     categoria: "Documentos",
     pergunta: "Onde emito meu histórico escolar?",
     resposta:
-      "No Catálogo, procure por ‘Histórico escolar’ ou ‘Declarações’. Abra um chamado e acompanhe o andamento em ‘Meus chamados’.",
+      "No Catálogo, procure por ‘Histórico escolar’ ou ‘Declarações’. Abra uma solicitação acadêmica e acompanhe o andamento em ‘Minhas solicitações’.",
     links: [
       { label: "Catálogo de Serviços", href: "/aluno/catalogo" },
-      { label: "Meus Chamados", href: "/aluno/chamados" },
+      { label: "Minhas solicitações", href: "/aluno/chamados" },
     ],
   },
   {
@@ -187,7 +187,7 @@ export default function AjudaAlunoPage() {
           <div>
             <div className="font-medium">Não achou o que precisava?</div>
             <div className="text-sm text-muted-foreground">
-              Abra um chamado e nossa equipe ajuda você com o seu caso.
+              Abra uma solicitação acadêmica e nossa equipe ajuda você com o seu caso.
             </div>
           </div>
         </div>
@@ -204,7 +204,7 @@ export default function AjudaAlunoPage() {
             className="inline-flex items-center gap-2 h-10 px-4 rounded-lg bg-primary text-primary-foreground hover:opacity-90"
           >
             <MessageSquare className="size-4" />
-            Abrir chamado
+            Abrir solicitação acadêmica
           </Link>
         </div>
       </div>

--- a/app/(dashboard)/aluno/catalogo/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/page.tsx
@@ -81,7 +81,7 @@ function ServicoCard({ s }: { s: Servico }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
 
-  async function handleAbrirChamado() {
+  async function handleAbrirSolicitacao() {
     if (!s.ativo) return;
     try {
       setLoading(true);
@@ -105,14 +105,14 @@ function ServicoCard({ s }: { s: Servico }) {
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
-        throw new Error(err.message || "Erro ao criar chamado");
+        throw new Error(err.message || "Erro ao criar solicitação acadêmica");
       }
 
       const data = await res.json();
-      toast.success("Chamado criado com sucesso!");
+      toast.success("Solicitação acadêmica criada com sucesso!");
       router.push(`/aluno/chamados/${data.id}`);
     } catch (err: any) {
-      toast.error(err.message || "Falha ao criar chamado");
+      toast.error(err.message || "Falha ao criar solicitação acadêmica");
     } finally {
       setLoading(false);
     }
@@ -138,7 +138,7 @@ function ServicoCard({ s }: { s: Servico }) {
         <div className="text-xs text-muted-foreground">ID: {s.id}</div>
         <button
           disabled={!s.ativo || loading}
-          onClick={handleAbrirChamado}
+          onClick={handleAbrirSolicitacao}
           className={cx(
             "inline-flex items-center gap-1.5 h-9 px-3 rounded-md text-sm transition",
             s.ativo
@@ -152,7 +152,7 @@ function ServicoCard({ s }: { s: Servico }) {
             </>
           ) : (
             <>
-              <Plus className="size-4" /> Abrir chamado
+              <Plus className="size-4" /> Iniciar solicitação
             </>
           )}
         </button>
@@ -221,8 +221,9 @@ export default function CatalogoAlunoPage() {
       {/* Topbar */}
       <div className="mb-6 flex items-center justify-between">
         <div>
+          <h1 className="font-grotesk text-2xl font-semibold tracking-tight">Serviços acadêmicos da Fatec</h1>
           <p className="text-xs text-muted-foreground mt-2">
-            Catálogo: {kpis.ativos} serviços disponíveis • {kpis.indisponiveis} indisponíveis
+            Central de Solicitações Acadêmicas Fatec: {kpis.ativos} disponíveis • {kpis.indisponiveis} indisponíveis
           </p>
         </div>
         <MobileSidebarTriggerAluno />

--- a/app/(dashboard)/aluno/chamados/[id]/page.tsx
+++ b/app/(dashboard)/aluno/chamados/[id]/page.tsx
@@ -19,6 +19,14 @@ import { apiFetch } from "../../../../../utils/api";
 /* ================= Tipos ================= */
 type Status = "ABERTO" | "EM_ATENDIMENTO" | "AGUARDANDO_USUARIO" | "RESOLVIDO" | "ENCERRADO";
 
+const STATUS_LABELS: Record<Status, string> = {
+  ABERTO: "Solicitação recebida pela Fatec.",
+  EM_ATENDIMENTO: "Em análise pelo setor responsável.",
+  AGUARDANDO_USUARIO: "Aguardando documento ou resposta do aluno.",
+  RESOLVIDO: "Solicitação respondida.",
+  ENCERRADO: "Atendimento finalizado.",
+};
+
 type Chamado = {
   id: string;
   titulo: string;
@@ -84,11 +92,11 @@ function confirmarEncerramento() {
 
         <div className="flex-1">
           <h3 className="text-sm font-semibold text-foreground">
-            Deseja encerrar este chamado?
+            Deseja finalizar esta solicitação acadêmica?
           </h3>
           <p className="text-sm text-muted-foreground mt-1 leading-snug">
-            Após encerrar, o chamado ficará <b>apenas para consulta</b> e{" "}
-            <b>não poderá ser reaberto</b>.
+            Após finalizar, a solicitação acadêmica ficará <b>apenas para consulta</b> e{" "}
+            <b>não poderá ser reaberta</b>.
           </p>
 
           <div className="mt-3 flex justify-end gap-2">
@@ -102,9 +110,9 @@ function confirmarEncerramento() {
               onClick={() => {
                 atualizarStatus("ENCERRADO");
                 toast.dismiss(t);
-                toast.success("Chamado encerrado com sucesso!", {
+                toast.success("Solicitação acadêmica finalizada com sucesso!", {
                   description:
-                    "Agora ele está disponível apenas para consulta no histórico.",
+                    "Agora ela está disponível apenas para consulta no histórico.",
                 });
               }}
               className="px-3 py-1.5 rounded-md text-sm bg-[#B91C1C] text-white hover:bg-[#991B1B] transition"
@@ -129,11 +137,11 @@ function confirmarReabertura() {
 
         <div className="flex-1">
           <h3 className="text-sm font-semibold text-foreground">
-            Reabrir chamado?
+            Reabrir solicitação acadêmica?
           </h3>
           <p className="text-sm text-muted-foreground mt-1 leading-snug">
-            O chamado voltará para o status <b>“Em atendimento”</b> e poderá
-            ser atualizado novamente pela secretaria.
+            A solicitação acadêmica voltará para o status <b>“Em análise pelo setor responsável”</b> e poderá
+            ser atualizada novamente pela secretaria.
           </p>
 
           <div className="mt-3 flex justify-end gap-2">
@@ -147,8 +155,8 @@ function confirmarReabertura() {
               onClick={() => {
                 atualizarStatus("EM_ATENDIMENTO");
                 toast.dismiss(t);
-                toast.success("Chamado reaberto com sucesso!", {
-                  description: "Agora ele está novamente em atendimento.",
+                toast.success("Solicitação acadêmica reaberta com sucesso!", {
+                  description: "Agora ela está novamente em análise pelo setor responsável.",
                 });
               }}
               className="px-3 py-1.5 rounded-md text-sm bg-blue-600 text-white hover:bg-blue-700 transition"
@@ -177,7 +185,7 @@ function confirmarReabertura() {
       const data: Chamado = await res.json();
       setChamado(data);
     } catch (err: any) {
-      toast.error(err.message || "Erro ao carregar chamado.");
+      toast.error(err.message || "Erro ao carregar solicitação acadêmica.");
     } finally {
       setLoading(false);
     }
@@ -327,8 +335,8 @@ function confirmarReabertura() {
       if (!res.ok) throw new Error(`Erro ${res.status}`);
       toast.success(
         novoStatus === "EM_ATENDIMENTO"
-          ? "Chamado reaberto com sucesso!"
-          : "Chamado encerrado com sucesso."
+          ? "Solicitação acadêmica reaberta com sucesso!"
+          : "Solicitação acadêmica finalizada com sucesso."
       );
       await fetchChamado();
     } catch (err: any) {
@@ -340,14 +348,14 @@ function confirmarReabertura() {
   if (loading && !chamado)
     return (
       <div className="flex items-center justify-center py-16 text-muted-foreground gap-2">
-        <Loader2 className="size-5 animate-spin" /> Carregando chamado...
+        <Loader2 className="size-5 animate-spin" /> Carregando solicitação acadêmica...
       </div>
     );
 
   if (!chamado)
     return (
       <div className="text-center py-16 text-muted-foreground">
-        Chamado não encontrado.
+        Solicitação acadêmica não encontrada.
       </div>
     );
 
@@ -369,7 +377,7 @@ function confirmarReabertura() {
           href="/aluno/chamados"
           className="inline-flex items-center gap-2 h-9 px-3 rounded-md border bg-background hover:bg-muted text-sm"
         >
-          Lista de chamados
+          Minhas solicitações
         </Link>
       </div>
 
@@ -386,7 +394,7 @@ function confirmarReabertura() {
             <span className="whitespace-pre-wrap">{chamado.descricao}</span>
           </p>
           <p>
-            <strong>Status:</strong> {chamado.status}
+            <strong>Status:</strong> {STATUS_LABELS[chamado.status] ?? chamado.status}
           </p>
           <p>
             <strong>Criado em:</strong>{" "}
@@ -395,7 +403,7 @@ function confirmarReabertura() {
         </div>
       </div>
 
-{/* Aviso para o aluno quando o chamado estiver resolvido */}
+{/* Aviso para o aluno quando a solicitação acadêmica estiver respondida */}
 {chamado.status === "RESOLVIDO" && (
   <div className="mt-4 rounded-lg border border-yellow-400/30 bg-yellow-100/20 text-yellow-700 dark:text-yellow-300 dark:bg-yellow-900/20 px-4 py-3 text-sm flex items-start gap-2">
     <svg
@@ -413,7 +421,7 @@ function confirmarReabertura() {
       />
     </svg>
     <div>
-      Este chamado foi marcado como <b>resolvido.</b> <br />
+      Esta solicitação acadêmica foi marcada como <b>respondida.</b> <br />
       Você pode <b>reabrir</b> caso o problema não tenha sido solucionado ou{" "}
       <b>encerrar</b> definitivamente se estiver tudo certo.
     </div>
@@ -432,14 +440,14 @@ function confirmarReabertura() {
       onClick={confirmarEncerramento}
       className="px-4 py-2 rounded-md bg-[#B91C1C] text-white text-sm font-medium hover:bg-[#991B1B] transition"
     >
-      Encerrar chamado
+      Finalizar atendimento
     </button>
 
     <button
       onClick={() => confirmarReabertura()}
       className="px-4 py-2 rounded-md bg-[#374151] text-white text-sm font-medium hover:bg-[#111827] transition"
     >
-      Reabrir chamado
+      Reabrir solicitação
     </button>
   </div>
 )}
@@ -449,7 +457,7 @@ function confirmarReabertura() {
       {/* Chat */}
       <section className="rounded-xl border border-[var(--border)] bg-card flex flex-col">
         <div className="p-3 border-b border-[var(--border)] text-xs text-muted-foreground">
-          Chat do chamado
+          Conversa sobre a solicitação
         </div>
 
         <div className="flex-1 p-4 space-y-3 overflow-y-auto max-h-[500px] rounded-b-lg scrollbar-thin">
@@ -510,7 +518,7 @@ function confirmarReabertura() {
           </div>
         ) : (
           <div className="p-3 border-t text-center text-sm text-muted-foreground">
-            🔒 Chamado encerrado. Disponível apenas para consulta.
+            🔒 Atendimento finalizado. Solicitação disponível apenas para consulta.
           </div>
         )}
       </section>

--- a/app/(dashboard)/aluno/chamados/page.tsx
+++ b/app/(dashboard)/aluno/chamados/page.tsx
@@ -50,7 +50,7 @@ function AcoesChamado({ c }: { c: Chamado }) {
 
   return (
     <div className="flex gap-2 justify-end">
-      {/* Link sempre visível: permite consultar o chamado mesmo encerrado */}
+      {/* Link sempre visível: permite consultar a solicitação acadêmica mesmo encerrada */}
       <Link
         href={`/aluno/chamados/${c.id}`}
         className={cx(base, "text-[var(--brand-teal)] border-[var(--brand-teal)]/40")}
@@ -109,7 +109,7 @@ export default function MeusChamadosPage() {
         const data: PageResp = await res.json();
         if (alive) setDados(data.items ?? []);
       } catch (err: any) {
-        toast.error("Erro ao carregar chamados", { description: err?.message });
+        toast.error("Erro ao carregar solicitações acadêmicas", { description: err?.message });
       } finally {
         if (alive) setLoading(false);
       }
@@ -141,7 +141,8 @@ export default function MeusChamadosPage() {
       {/* Topbar mínima (sem saudação; cabeçalho global está no layout) */}
       <div className="mb-6 flex items-center justify-between">
         <div>
-          <p className="text-muted-foreground">Acompanhe e gerencie seus chamados.</p>
+          <h1 className="font-grotesk text-2xl font-semibold tracking-tight">Minhas solicitações acadêmicas</h1>
+          <p className="text-muted-foreground">Acompanhe suas solicitações acadêmicas junto à Fatec.</p>
         </div>
         <MobileSidebarTriggerAluno />
       </div>
@@ -153,7 +154,7 @@ export default function MeusChamadosPage() {
             <div className="flex items-start gap-3">
               <AlertTriangle className="size-5 text-[var(--warning)] mt-0.5" />
               <div>
-                <div className="font-medium">Você tem {aguardandoCount} chamado(s) aguardando sua ação.</div>
+                <div className="font-medium">Você tem {aguardandoCount} solicitação(ões) acadêmica(s) aguardando sua ação.</div>
                 <div className="text-sm text-muted-foreground">
                   Envie documentos, responda mensagens ou conclua a tarefa.
                 </div>
@@ -164,7 +165,7 @@ export default function MeusChamadosPage() {
               className="inline-flex items-center h-9 px-3 rounded-md border border-[var(--warning)]/40 text-[var(--warning)] hover:bg-[var(--warning)]/10"
               onClick={() => setStatus("AGUARDANDO_USUARIO")}
             >
-              Filtrar por “Aguardando você”
+              Filtrar solicitações aguardando você
             </button>
           </div>
         </div>
@@ -177,7 +178,7 @@ export default function MeusChamadosPage() {
             href="/aluno/catalogo"
             className="inline-flex items-center gap-2 h-10 px-4 rounded-lg bg-primary text-primary-foreground hover:opacity-90"
           >
-            <Plus className="size-4" /> Abrir novo chamado
+            <Plus className="size-4" /> Abrir solicitação acadêmica
           </Link>
         </div>
 
@@ -199,11 +200,11 @@ export default function MeusChamadosPage() {
             onChange={(e) => setStatus(e.target.value as any)}
           >
             <option value="ALL">Todos os status</option>
-            <option value="ABERTO">Aberto</option>
-            <option value="EM_ATENDIMENTO">Em atendimento</option>
-            <option value="AGUARDANDO_USUARIO">Aguardando você</option>
-            <option value="RESOLVIDO">Resolvido</option>
-            <option value="ENCERRADO">Encerrado</option>
+            <option value="ABERTO">Solicitação recebida pela Fatec.</option>
+            <option value="EM_ATENDIMENTO">Em análise pelo setor responsável.</option>
+            <option value="AGUARDANDO_USUARIO">Aguardando documento ou resposta do aluno.</option>
+            <option value="RESOLVIDO">Solicitação respondida.</option>
+            <option value="ENCERRADO">Atendimento finalizado.</option>
           </select>
         </div>
       </div>
@@ -217,7 +218,7 @@ export default function MeusChamadosPage() {
           </div>
         ) : filtrados.length === 0 ? (
           <div className="p-8 text-center text-muted-foreground">
-            Nenhum chamado encontrado com os filtros atuais.
+            Nenhuma solicitação acadêmica encontrada com os filtros atuais.
           </div>
         ) : (
           <>

--- a/app/(dashboard)/aluno/configuracoes/page.tsx
+++ b/app/(dashboard)/aluno/configuracoes/page.tsx
@@ -166,7 +166,7 @@ export default function ConfiguracoesAlunoPage() {
             <div>
               <div className="font-medium">Notificações por e-mail</div>
               <div className="text-sm text-muted-foreground">
-                Receba alertas sobre atualizações de chamados e mensagens.
+                Receba alertas sobre atualizações de solicitações acadêmicas e mensagens.
               </div>
             </div>
           </div>

--- a/app/(dashboard)/aluno/home/page.tsx
+++ b/app/(dashboard)/aluno/home/page.tsx
@@ -59,7 +59,7 @@ export default function AlunoHomePage() {
           const res = await fetch(`${base}&page=${page}&pageSize=${pageSize}`, {
             headers: { Authorization: `Bearer ${token}` },
           });
-          if (!res.ok) throw new Error("Erro ao buscar chamados");
+          if (!res.ok) throw new Error("Erro ao buscar solicitações acadêmicas");
           const data = await res.json(); // { total, page, pageSize, items }
           if (page === 1) total = data.total ?? 0;
 
@@ -74,7 +74,7 @@ export default function AlunoHomePage() {
         setChamados(all);
       } catch (err) {
         console.error(err);
-        toast.error("Erro ao carregar chamados");
+        toast.error("Erro ao carregar solicitações acadêmicas");
       } finally {
         setLoading(false);
       }
@@ -122,10 +122,10 @@ export default function AlunoHomePage() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <KpiCard
           icon={<Ticket className="size-4" />}
-          label="Abertos"
+          label="Recebidas"
           value={kpi.abertos}
           tone="brand-cyan"
-          hint="Chamados em aberto"
+          hint="Solicitações recebidas pela Fatec"
         />
         <KpiCard
           icon={<AlertTriangle className="size-4" />}
@@ -136,27 +136,27 @@ export default function AlunoHomePage() {
         />
         <KpiCard
           icon={<Clock className="size-4" />}
-          label="Em atendimento"
+          label="Em análise"
           value={kpi.emAtendimento}
           tone="brand-teal"
         />
         <KpiCard
           icon={<CheckCircle2 className="size-4" />}
-          label="Resolvidos"
+          label="Respondidas"
           value={kpi.resolvidos}
           tone="success"
         />
       </div>
 
-      {/* Lista de chamados */}
+      {/* Lista de solicitações acadêmicas */}
       <div className="rounded-xl border border-[var(--border)] bg-card overflow-hidden">
         {loading ? (
           <div className="p-8 text-center text-muted-foreground">
-            Carregando chamados...
+            Carregando solicitações acadêmicas...
           </div>
         ) : chamadosVisiveis.length === 0 ? (
           <div className="p-8 text-center text-muted-foreground">
-            Nenhum chamado encontrado.
+            Nenhuma solicitação acadêmica encontrada.
           </div>
         ) : (
           <div className="overflow-x-auto">
@@ -208,7 +208,7 @@ export default function AlunoHomePage() {
                   onClick={() => setLimite(chamadosAtivos.length)}
                   className="text-sm font-medium text-[var(--brand-red)] hover:underline"
                 >
-                  Ver todos os {chamadosAtivos.length} chamados
+                  Ver todas as {chamadosAtivos.length} solicitações acadêmicas
                 </button>
               </div>
             )}

--- a/app/(dashboard)/aluno/notificacoes/page.tsx
+++ b/app/(dashboard)/aluno/notificacoes/page.tsx
@@ -205,7 +205,7 @@ await apiFetch(`${apiBase}/notifications/read-all`, {
                           href={`/aluno/chamados/${n.chamadoId}`}
                           className="text-[var(--brand-cyan)] hover:underline"
                         >
-                          Ver chamado →
+                          Ver solicitação →
                         </Link>
                       )}
                       {n.meta?.url && (

--- a/app/components/shared/NivelBadge.tsx
+++ b/app/components/shared/NivelBadge.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 
 /**
- * Exibe um badge formatado para o Nível do chamado (N1, N2, N3).
+ * Exibe um badge formatado para o Nível da solicitação acadêmica (N1, N2, N3).
  */
 export default function NivelBadge({ nivel }: Props) {
   const map: Record<Nivel, string> = {

--- a/app/components/shared/PriorityDot.tsx
+++ b/app/components/shared/PriorityDot.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 /**
- * Exibe um ponto colorido que indica a prioridade do chamado.
+ * Exibe um ponto colorido que indica a prioridade da solicitação acadêmica.
  */
 export default function PriorityDot({ prioridade, className = "size-2" }: Props) {
   const map: Record<Prioridade, string> = {

--- a/app/components/shared/TicketStatusBadge.tsx
+++ b/app/components/shared/TicketStatusBadge.tsx
@@ -14,29 +14,29 @@ type Props = {
 };
 
 /**
- * Badge padronizado para exibir o Status de um chamado.
+ * Badge padronizado para exibir o status de uma solicitação acadêmica.
  */
 export default function TicketStatusBadge({ status }: Props) {
   // Mapeamento centralizado de cores e textos
   const map: Record<Status, { label: string; cls: string }> = {
     ABERTO: {
-      label: "Aberto",
+      label: "Solicitação recebida pela Fatec.",
       cls: "bg-[var(--brand-cyan)]/12 text-[var(--brand-cyan)] border-[var(--brand-cyan)]/30",
     },
     EM_ATENDIMENTO: {
-      label: "Em atendimento",
+      label: "Em análise pelo setor responsável.",
       cls: "bg-[var(--brand-teal)]/12 text-[var(--brand-teal)] border-[var(--brand-teal)]/30",
     },
     AGUARDANDO_USUARIO: {
-      label: "Aguardando você", // ou "Aguard. usuário"
+      label: "Aguardando documento ou resposta do aluno.",
       cls: "bg-[var(--warning)]/12 text-[var(--warning)] border-[var(--warning)]/30",
     },
     RESOLVIDO: {
-      label: "Resolvido",
+      label: "Solicitação respondida.",
       cls: "bg-[var(--success)]/12 text-[var(--success)] border-[var(--success)]/30",
     },
     ENCERRADO: {
-      label: "Encerrado",
+      label: "Atendimento finalizado.",
       cls: "bg-[var(--muted)] text-muted-foreground border-[var(--border)]",
     },
   };


### PR DESCRIPTION
### Motivation
- Tornar a linguagem das telas do aluno mais amigável e consistente, substituindo “chamado” por “solicitação acadêmica” nas interfaces voltadas ao aluno. 
- Destacar o catálogo como ponto central de serviços acadêmicos e ajustar CTAs/mensagens para refletir o fluxo de solicitações acadêmicas. 
- Padronizar os labels de status para mensagens claras ao aluno (ABERTO, EM_ATENDIMENTO, AGUARDANDO_USUARIO, RESOLVIDO, ENCERRADO). 

### Description
- Atualiza o Catálogo do aluno (`app/(dashboard)/aluno/catalogo/page.tsx`): título para “Serviços acadêmicos da Fatec”, subtítulo “Central de Solicitações Acadêmicas Fatec”, renomeia ação de abertura para `handleAbrirSolicitacao` e botão para “Iniciar solicitação”, e ajusta mensagens de sucesso/erro para “solicitação acadêmica”.
- Atualiza listagem de solicitações (`app/(dashboard)/aluno/chamados/page.tsx`): título para “Minhas solicitações acadêmicas”, banner/mensagens CTA para linguagem de solicitação acadêmica, botão “Abrir solicitação acadêmica” e opções de filtro com labels amigáveis para o aluno.
- Atualiza detalhe da solicitação (`app/(dashboard)/aluno/chamados/[id]/page.tsx`): adiciona `STATUS_LABELS` para tradução amigável dos status, exibe o label legível no campo Status, altera textos de confirmação (finalizar/reabrir) e toasts para “solicitação acadêmica”, e ajusta textos do chat/anexos para a nova terminologia.
- Centraliza e altera os labels públicos de status em `app/components/shared/TicketStatusBadge.tsx` para: “Solicitação recebida pela Fatec.”, “Em análise pelo setor responsável.”, “Aguardando documento ou resposta do aluno.”, “Solicitação respondida.” e “Atendimento finalizado.”
- Ajustes em componentes e telas auxiliares do portal aluno para consistência: `SidebarAluno`, `AlunoTopbar`, `Ajuda`, `Home`, `Notificações`, `Configurações` e comentários/documentação em `NivelBadge` e `PriorityDot` para não usar “chamado” no contexto do aluno.
- As mudanças são textuais e de rótulo; a lógica de negócio e os componentes compartilhados foram preservados (apenas labels/textos alterados para o contexto do aluno).

### Testing
- Executado `pnpm exec eslint app/components/shared/TicketStatusBadge.tsx app/components/shared/NivelBadge.tsx app/components/shared/PriorityDot.tsx`, que passou sem erros para os arquivos alterados. 
- Executado `pnpm lint` (linter do repositório), que falhou devido a problemas preexistentes em vários arquivos (uso de `any`, imports não usados e avisos de hooks); essas falhas não foram introduzidas por este PR e estavam presentes no repositório antes das mudanças. 
- Verifiquei presença de `node_modules` no ambiente e confirmei que não há navegador/headless disponível para capturas visuais (nenhum `chromium` instalado), portanto não foram feitos testes visuais automatizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd32a33020832e8b2229f49f567c01)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Adicionada a funcionalidade "Marcar todas como lidas" na página de notificações
  * Labels descritivos para cada status de solicitação agora exibem mensagens mais claras e informativas

* **Refactor**
  * Atualizada a terminologia em toda a plataforma de "chamado" para "solicitação acadêmica", incluindo cabeçalhos, botões, mensagens e indicadores do dashboard
  * Reorganizados rótulos nos indicadores rápidos para melhor clareza ("Aguardando você" → "Aguardando resposta"; "Abertos" → "Recebidas")

<!-- end of auto-generated comment: release notes by coderabbit.ai -->