### PR TITLE
Atualiza catálogo institucional da Fatec

### DIFF
--- a/app/(dashboard)/aluno/catalogo/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/page.tsx
@@ -5,61 +5,17 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Search, Layers, BookOpen, Plus, Loader2 } from "lucide-react";
 import MobileSidebarTriggerAluno from "../_components/MobileSidebarTriggerAluno";
-import { cx } from '../../../../utils/cx'
+import { CATALOGO_INSTITUCIONAL, type CatalogResponse, type ServicoCatalogo } from "../../../../utils/catalogo";
+import { cx } from "../../../../utils/cx";
 
-/* ----------------------------- Tipos ----------------------------- */
-type Servico = {
-  id: string;
-  nome: string;
-  descricao?: string | null;
-  ativo: boolean;
-  categoriaId?: string | null;
-};
+type Servico = ServicoCatalogo & { categoriaNome?: string };
 
-type Categoria = {
-  id: string;
-  nome: string;
-  descricao?: string | null;
-  servicos: Servico[];
-};
-
-type CatalogResponse = {
-  categorias: Categoria[];
-};
+function getErrorMessage(err: unknown, fallback: string) {
+  return err instanceof Error ? err.message : fallback;
+}
 
 /* ----------------------------- MOCK (fallback) ----------------------------- */
-const MOCK: CatalogResponse = {
-  categorias: [
-    {
-      id: "cat-secretaria",
-      nome: "Secretaria",
-      descricao: "Atendimentos acadêmicos e documentação",
-      servicos: [
-        { id: "s1", nome: "Revisão de nota", descricao: "Solicite revisão da avaliação", ativo: true },
-        { id: "s2", nome: "Histórico escolar", descricao: "Gere histórico/declarações", ativo: true },
-        { id: "s3", nome: "Aproveitamento de estudos", descricao: "Solicite análise de equivalência curricular", ativo: false },
-      ],
-    },
-    {
-      id: "cat-financeiro",
-      nome: "Financeiro",
-      descricao: "Pagamentos e documentos financeiros",
-      servicos: [
-        { id: "s4", nome: "2ª via de boleto", descricao: "Emissão de boleto atualizado", ativo: true },
-        { id: "s5", nome: "Negociação de débito", descricao: "Abra uma negociação financeira", ativo: true },
-      ],
-    },
-    {
-      id: "cat-ti",
-      nome: "TI Acadêmica",
-      descricao: "Acesso, e-mail e sistemas",
-      servicos: [
-        { id: "s6", nome: "Problemas no e-mail educacional", descricao: "Criação, acesso e ajustes", ativo: true },
-        { id: "s7", nome: "Troca de senha", descricao: "Redefinição de senha institucional", ativo: true },
-      ],
-    },
-  ],
-};
+const MOCK: CatalogResponse = CATALOGO_INSTITUCIONAL;
 
 /* ----------------------------- Componentes ----------------------------- */
 function CategoriaPill({ label, active, onClick }: { label: string; active?: boolean; onClick: () => void }) {
@@ -111,8 +67,8 @@ function ServicoCard({ s }: { s: Servico }) {
       const data = await res.json();
       toast.success("Solicitação acadêmica criada com sucesso!");
       router.push(`/aluno/chamados/${data.id}`);
-    } catch (err: any) {
-      toast.error(err.message || "Falha ao criar solicitação acadêmica");
+    } catch (err: unknown) {
+      toast.error(getErrorMessage(err, "Falha ao criar solicitação acadêmica"));
     } finally {
       setLoading(false);
     }
@@ -173,7 +129,8 @@ export default function CatalogoAlunoPage() {
   useEffect(() => {
     async function fetchCatalog() {
       try {
-        const url = `${process.env.NEXT_PUBLIC_API_BASE_URL}/catalogo`;
+        const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+        const url = apiBaseUrl ? `${apiBaseUrl}/catalogo` : "/catalogo";
         const res = await fetch(url, { cache: "no-store" });
         if (!res.ok) throw new Error("fallback");
         const data = (await res.json()) as CatalogResponse;
@@ -190,7 +147,7 @@ export default function CatalogoAlunoPage() {
   }, []);
 
   const flatServicos = useMemo(
-    () => catalog.categorias.flatMap((c) => c.servicos.map((s) => ({ ...s, categoriaId: c.id }))),
+    () => catalog.categorias.flatMap((c) => c.servicos.map((s) => ({ ...s, categoriaId: c.id, categoriaNome: c.nome }))),
     [catalog]
   );
 
@@ -203,7 +160,11 @@ export default function CatalogoAlunoPage() {
     const texto = q.trim().toLowerCase();
     return flatServicos.filter((s) => {
       const byCat = catId === "ALL" || s.categoriaId === catId;
-      const byText = !texto || s.nome.toLowerCase().includes(texto) || (s.descricao ?? "").toLowerCase().includes(texto);
+      const searchable = [s.nome, s.descricao, s.categoriaNome, ...(s.palavrasChave ?? [])]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      const byText = !texto || searchable.includes(texto);
       return byCat && byText;
     });
   }, [flatServicos, q, catId]);
@@ -241,7 +202,7 @@ export default function CatalogoAlunoPage() {
         <div className="relative w-full lg:w-[360px]">
           <Search className="size-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2" />
           <input
-            placeholder="Buscar por nome ou descrição"
+            placeholder="Buscar por nome, descrição, categoria ou CPS/Fatec"
             className="w-full h-10 rounded-lg border border-[var(--border)] bg-input px-9 focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
             value={q}
             onChange={(e) => setQ(e.target.value)}

--- a/app/catalogo/route.ts
+++ b/app/catalogo/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { CATALOGO_INSTITUCIONAL } from "../../utils/catalogo";
+
+export async function GET() {
+  return NextResponse.json(CATALOGO_INSTITUCIONAL, {
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/utils/catalogo.ts
+++ b/utils/catalogo.ts
@@ -1,0 +1,269 @@
+export type FormularioCampo = {
+  id: string;
+  label: string;
+  tipo: "texto" | "textarea" | "select" | "arquivo" | "data";
+  obrigatorio: boolean;
+  opcoes?: string[];
+  ajuda?: string;
+};
+
+export type FormularioMetadata = {
+  versao: number;
+  disponivel: boolean;
+  campos: FormularioCampo[];
+};
+
+export type ServicoCatalogo = {
+  id: string;
+  nome: string;
+  descricao: string;
+  ativo: boolean;
+  categoriaId: string;
+  palavrasChave: string[];
+  formulario: FormularioMetadata;
+};
+
+export type CategoriaCatalogo = {
+  id: string;
+  nome: string;
+  descricao: string;
+  palavrasChave: string[];
+  servicos: ServicoCatalogo[];
+};
+
+export type CatalogResponse = {
+  categorias: CategoriaCatalogo[];
+};
+
+const FORMULARIO_FUTURO: FormularioMetadata = {
+  versao: 1,
+  disponivel: false,
+  campos: [],
+};
+
+const fatecKeywords = [
+  "cps",
+  "centro paula souza",
+  "fatec",
+  "faculdade de tecnologia",
+  "secretaria acadêmica fatec",
+  "siga",
+  "sistema integrado de gestão acadêmica",
+];
+
+function servico(
+  categoriaId: string,
+  id: string,
+  nome: string,
+  descricao: string,
+  palavrasChave: string[],
+  ativo = true
+): ServicoCatalogo {
+  return {
+    id,
+    nome,
+    descricao,
+    ativo,
+    categoriaId,
+    palavrasChave: [...palavrasChave, ...fatecKeywords],
+    formulario: FORMULARIO_FUTURO,
+  };
+}
+
+export const CATALOGO_INSTITUCIONAL: CatalogResponse = {
+  categorias: [
+    {
+      id: "secretaria-academica",
+      nome: "Secretaria Acadêmica",
+      descricao: "Documentos, registros acadêmicos, matrícula, rematrícula e correções cadastrais.",
+      palavrasChave: ["secretaria", "acadêmico", "documentação", "registro", "aluno", ...fatecKeywords],
+      servicos: [
+        servico(
+          "secretaria-academica",
+          "secretaria-declaracao-matricula",
+          "Declaração de matrícula",
+          "Solicite declaração de matrícula ativa para comprovação acadêmica, estágio ou benefícios estudantis.",
+          ["declaração", "matrícula", "comprovante", "vínculo", "atestado"]
+        ),
+        servico(
+          "secretaria-academica",
+          "secretaria-historico-escolar",
+          "Histórico escolar",
+          "Solicite emissão ou atualização do histórico escolar com disciplinas, cargas horárias e menções.",
+          ["histórico", "boletim", "disciplinas", "notas", "menções"]
+        ),
+        servico(
+          "secretaria-academica",
+          "secretaria-aproveitamento-estudos",
+          "Aproveitamento de estudos",
+          "Abra pedido de aproveitamento de estudos cursados anteriormente para análise acadêmica.",
+          ["aproveitamento", "equivalência", "dispensa", "disciplinas cursadas", "análise curricular"]
+        ),
+        servico(
+          "secretaria-academica",
+          "secretaria-revisao-nota",
+          "Revisão de nota",
+          "Solicite revisão de nota ou menção registrada em disciplina, avaliação ou atividade acadêmica.",
+          ["revisão", "nota", "menção", "avaliação", "correção"]
+        ),
+        servico(
+          "secretaria-academica",
+          "secretaria-correcao-dados-siga",
+          "Correção de dados no SIGA",
+          "Informe divergências cadastrais para correção ou encaminhamento de ajuste no SIGA.",
+          ["correção", "dados", "cadastro", "siga", "divergência"]
+        ),
+        servico(
+          "secretaria-academica",
+          "secretaria-rematricula-fora-prazo",
+          "Rematrícula fora do prazo",
+          "Solicite orientação ou regularização de rematrícula após o período previsto no calendário acadêmico.",
+          ["rematrícula", "fora do prazo", "calendário acadêmico", "regularização"]
+        ),
+        servico(
+          "secretaria-academica",
+          "secretaria-trancamento-destrancamento",
+          "Trancamento/destrancamento",
+          "Solicite informações e abertura de processo de trancamento ou destrancamento de matrícula.",
+          ["trancamento", "destrancamento", "matrícula", "reativação", "interrupção"]
+        ),
+      ],
+    },
+    {
+      id: "coordenacao-curso",
+      nome: "Coordenação de Curso",
+      descricao: "Orientações pedagógicas, matriz curricular, equivalências e acompanhamento acadêmico.",
+      palavrasChave: ["coordenação", "curso", "coordenador", "pedagógico", "matriz", ...fatecKeywords],
+      servicos: [
+        servico(
+          "coordenacao-curso",
+          "coordenacao-duvida-matriz-curricular",
+          "Dúvida sobre matriz curricular",
+          "Envie dúvidas sobre matriz curricular, pré-requisitos, componentes curriculares e percurso formativo.",
+          ["matriz curricular", "grade", "pré-requisito", "componentes", "disciplinas"]
+        ),
+        servico(
+          "coordenacao-curso",
+          "coordenacao-reuniao",
+          "Solicitação de reunião com coordenação",
+          "Solicite agendamento de reunião com a coordenação do curso para orientação acadêmica.",
+          ["reunião", "agendamento", "coordenação", "orientação", "atendimento"]
+        ),
+        servico(
+          "coordenacao-curso",
+          "coordenacao-analise-disciplina-equivalencia",
+          "Análise de disciplina/equivalência",
+          "Peça análise de disciplina, equivalência, compatibilidade de ementa ou aproveitamento curricular.",
+          ["equivalência", "ementa", "disciplina", "análise", "compatibilidade"]
+        ),
+        servico(
+          "coordenacao-curso",
+          "coordenacao-orientacao-tg-tcc-projeto-integrador",
+          "Orientação sobre TG/TCC/projeto integrador",
+          "Solicite orientação sobre regras, etapas e encaminhamentos de TG, TCC ou projeto integrador.",
+          ["tg", "tcc", "trabalho de graduação", "projeto integrador", "orientação"]
+        ),
+      ],
+    },
+    {
+      id: "estagio",
+      nome: "Estágio",
+      descricao: "Documentos, contratos, relatórios e dúvidas sobre estágio obrigatório e não obrigatório.",
+      palavrasChave: ["estágio", "empresa", "supervisor", "concedente", "fatec", ...fatecKeywords],
+      servicos: [
+        servico(
+          "estagio",
+          "estagio-termo-compromisso",
+          "Termo de compromisso",
+          "Encaminhe solicitação relacionada ao termo de compromisso de estágio.",
+          ["termo de compromisso", "contrato", "estagiário", "empresa", "concedente"]
+        ),
+        servico(
+          "estagio",
+          "estagio-termo-aditivo",
+          "Termo aditivo",
+          "Solicite análise ou orientação sobre termo aditivo de estágio.",
+          ["termo aditivo", "prorrogação", "alteração", "vigência", "carga horária"]
+        ),
+        servico(
+          "estagio",
+          "estagio-relatorio",
+          "Relatório de estágio",
+          "Envie dúvidas ou solicite orientação sobre relatório parcial ou final de estágio.",
+          ["relatório", "parcial", "final", "atividades", "supervisor"]
+        ),
+        servico(
+          "estagio",
+          "estagio-rescisao",
+          "Rescisão",
+          "Solicite orientação sobre encerramento, rescisão ou baixa de estágio.",
+          ["rescisão", "encerramento", "baixa", "cancelamento", "término"]
+        ),
+        servico(
+          "estagio",
+          "estagio-duvida-obrigatorio-nao-obrigatorio",
+          "Dúvida sobre estágio obrigatório/não obrigatório",
+          "Tire dúvidas sobre regras, prazos e documentação de estágio obrigatório ou não obrigatório.",
+          ["obrigatório", "não obrigatório", "regras", "documentação", "prazo"]
+        ),
+      ],
+    },
+    {
+      id: "sistemas-institucionais-siga",
+      nome: "Sistemas Institucionais / SIGA",
+      descricao: "Acesso ao SIGA, e-mail institucional, senhas e divergências em sistemas acadêmicos.",
+      palavrasChave: ["sistemas", "siga", "e-mail institucional", "senha", "acesso", ...fatecKeywords],
+      servicos: [
+        servico(
+          "sistemas-institucionais-siga",
+          "sistemas-problema-acesso-siga",
+          "Problema de acesso ao SIGA",
+          "Relate falhas de login, bloqueios ou dificuldades para acessar o SIGA.",
+          ["acesso", "login", "bloqueio", "siga", "erro"]
+        ),
+        servico(
+          "sistemas-institucionais-siga",
+          "sistemas-dados-divergentes-siga",
+          "Dados divergentes no SIGA",
+          "Informe inconsistências de dados acadêmicos ou cadastrais exibidos no SIGA.",
+          ["dados divergentes", "inconsistência", "cadastro", "disciplinas", "siga"]
+        ),
+        servico(
+          "sistemas-institucionais-siga",
+          "sistemas-email-institucional",
+          "Problema com e-mail institucional",
+          "Abra solicitação para problemas de acesso, recebimento ou configuração do e-mail institucional.",
+          ["e-mail institucional", "email", "outlook", "conta", "mensagens"]
+        ),
+        servico(
+          "sistemas-institucionais-siga",
+          "sistemas-redefinicao-senha-institucional",
+          "Redefinição de senha institucional",
+          "Solicite apoio para redefinição de senha institucional ou recuperação de credenciais.",
+          ["senha", "redefinição", "credenciais", "recuperação", "login"]
+        ),
+      ],
+    },
+    {
+      id: "biblioteca",
+      nome: "Biblioteca",
+      descricao: "Atendimento sobre acervo, empréstimos, normalização e acesso a recursos informacionais.",
+      palavrasChave: ["biblioteca", "acervo", "empréstimo", "livros", "bases digitais", ...fatecKeywords],
+      servicos: [],
+    },
+    {
+      id: "diretoria-administrativo",
+      nome: "Diretoria / Administrativo",
+      descricao: "Demandas administrativas, encaminhamentos institucionais e assuntos da diretoria.",
+      palavrasChave: ["diretoria", "administrativo", "institucional", "gestão", "encaminhamento", ...fatecKeywords],
+      servicos: [],
+    },
+    {
+      id: "apoio-academico",
+      nome: "Apoio Acadêmico",
+      descricao: "Acolhimento, acompanhamento acadêmico e suporte complementar à permanência estudantil.",
+      palavrasChave: ["apoio", "acolhimento", "permanência", "orientação", "suporte acadêmico", ...fatecKeywords],
+      servicos: [],
+    },
+  ],
+};


### PR DESCRIPTION
### Motivation
- Centralizar o catálogo institucional com categorias e serviços alinhados à organização (Secretaria Acadêmica, Coordenação de Curso, Estágio, Sistemas Institucionais / SIGA, Biblioteca, Diretoria / Administrativo, Apoio Acadêmico).
- Fornecer serviços iniciais para Secretaria, Coordenação, Estágio e Sistemas (SIGA) com descrições e palavras‑chave relacionadas a CPS/Fatec e metadados de formulário para uso futuro.
- Preparar um endpoint backend que retorne categorias, serviços, status (ativo) e metadados de formulário para consumo pela UI.
- Melhorar a busca do catálogo para considerar nome, descrição, categoria e palavras‑chave relacionadas a CPS/Fatec.

### Description
- Adiciona `utils/catalogo.ts` com tipos (`ServicoCatalogo`, `CategoriaCatalogo`, `FormularioMetadata`), metadados de formulário e o `CATALOGO_INSTITUCIONAL` contendo as categorias e serviços solicitados.
- Cria o endpoint `GET /catalogo` em `app/catalogo/route.ts` que retorna o `CATALOGO_INSTITUCIONAL` com `Cache-Control: no-store`.
- Atualiza `app/(dashboard)/aluno/catalogo/page.tsx` para usar o catálogo institucional como fallback/mock, mapear `palavrasChave` e `categoriaNome`, ajustar placeholder de busca e ampliar o filtro para pesquisar em nome, descrição, categoria e palavras‑chave; também adiciona tratamento seguro de mensagens de erro.
- Inclui serviços iniciais solicitados (Declaração de matrícula, Histórico, Aproveitamento de estudos, Revisão de nota, Correção de dados no SIGA, Rematrícula fora do prazo, Trancamento/destrancamento, além dos serviços de Coordenação, Estágio e Sistemas/SIGA).

### Testing
- Executado `pnpm exec eslint app/'(dashboard)'/aluno/catalogo/page.tsx app/catalogo/route.ts utils/catalogo.ts` e não foram reportados erros nas entidades alteradas.
- Executado `pnpm exec tsc --noEmit` com sucesso, sem erros de tipo.
- Subido servidor de desenvolvimento (`pnpm exec next dev --turbopack -H 127.0.0.1 -p 3020`) e verificado `GET /catalogo` com `curl`, que retornou o catálogo com `7 categorias` e `20 servicos` conforme esperado.
- `pnpm lint` (sem escopo) falhou por erros de lint pré‑existentes em arquivos fora do escopo desta alteração; portanto somente a verificação dos arquivos modificados foi considerada verde.
- `pnpm build` falhou no ambiente porque o processo de build não conseguiu baixar fontes do Google via `next/font` (erro externo de rede).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd34186a7c832e825727883d4d9934)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Catálogo agora busca dados de forma mais resiliente, com fallback automático para endpoint local caso necessário.
  * Busca expandida: serviços são agora pesquisáveis por nome, descrição, categoria e palavras-chave.
  * Placeholder de busca atualizado para refletir novos campos pesquisáveis.
  * Nova rota API de catálogo disponível para consumo externo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->