### PR TITLE
feat(chamados): add academic ticket fields/types and surface academic data in UI (frontend)

### DIFF
--- a/app/(dashboard)/admin/chamados/[id]/page.tsx
+++ b/app/(dashboard)/admin/chamados/[id]/page.tsx
@@ -10,19 +10,13 @@ import {
 } from "lucide-react";
 import { apiFetch } from "../../../../../utils/api";
 import { toast } from "sonner";
+import type { Chamado, Nivel, Prioridade, SetorMin, ServicoMin, Status, UsuarioMin } from "../../../../../utils/types";
 
 import { cx } from '../../../../../utils/cx'
 import TicketStatusBadge from "../../../../components/shared/TicketStatusBadge";
 import LoadingSpinner from "../../../../components/shared/LoadingSpinner";
 
 /* ===== Tipos ===== */
-type Nivel = "N1" | "N2" | "N3";
-type Status = "ABERTO" | "EM_ATENDIMENTO" | "AGUARDANDO_USUARIO" | "RESOLVIDO" | "ENCERRADO";
-type Prioridade = "BAIXA" | "MEDIA" | "ALTA" | "URGENTE";
-
-type UsuarioMin = { id: string; nome?: string | null; emailPessoal?: string | null };
-type SetorMin = { id: string; nome?: string | null };
-type ServicoMin = { id: string; nome?: string | null };
 type ClienteMin = { id: string; nome?: string | null };
 type ContratoMin = { id: string; numero?: string | null };
 
@@ -53,18 +47,12 @@ type AnexoInfo = {
   enviadoPor?: { id: string; nome?: string | null } | null;
 };
 
-type Ticket = {
-  id: string;
-  protocolo?: string | null;
-  titulo: string;
+type Ticket = Chamado & {
   descricao: string;
   nivel: Nivel;
-  status: Status;
   prioridade: Prioridade;
   criadoPorId: string;
-  criadoEm: string;
   atualizadoEm: string;
-  encerradoEm?: string | null;
 
   criadoPor?: UsuarioMin | null;
   responsavel?: UsuarioMin | null;
@@ -76,6 +64,44 @@ type Ticket = {
   historico?: Historico[];
 };
 
+function formatOptional(value: unknown): string {
+  if (Array.isArray(value)) return value.filter(Boolean).join(", ") || "—";
+  if (value === null || value === undefined || value === "") return "—";
+  return String(value);
+}
+
+function formatDateTimeOptional(value?: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function InfoItem({
+  label,
+  value,
+  multiline = false,
+}: {
+  label: string;
+  value: unknown;
+  multiline?: boolean;
+}) {
+  return (
+    <div className={cx("min-w-0", multiline && "rounded-lg border border-[var(--border)] bg-background p-3")}>
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className={cx("font-medium", multiline ? "mt-1 whitespace-pre-wrap" : "truncate")}>
+        {formatOptional(value)}
+      </div>
+    </div>
+  );
+}
+
 /* ===== Página ===== */
 export default function AdminChamadoPage() {
   const { id } = useParams<{ id: string }>();
@@ -85,8 +111,6 @@ export default function AdminChamadoPage() {
   // dados gerais
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
   // edição
   const [status, setStatus] = useState<Status>("ABERTO");
   const [prioridade, setPrioridade] = useState<Prioridade>("MEDIA");
@@ -111,6 +135,7 @@ export default function AdminChamadoPage() {
     () =>
       [
         "criadoPor",
+        "aluno",
         "responsavel",
         "setor",
         "servico",
@@ -130,9 +155,10 @@ export default function AdminChamadoPage() {
       if (!res.ok) throw new Error("Falha ao buscar anexos");
       const data = await res.json();
       setAnexos(Array.isArray(data) ? data : []);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro desconhecido";
       console.error("Erro ao buscar anexos:", err);
-      toast.error("Falha ao carregar anexos.", { description: err.message });
+      toast.error("Falha ao carregar anexos.", { description: message });
     } finally {
       setLoadingAnexos(false);
     }
@@ -142,14 +168,12 @@ export default function AdminChamadoPage() {
     if (!id || !API) return;
     try {
       setLoading(true);
-      setErr(null);
-
       const res = await apiFetch(`${API}/tickets/${id}?include=${encodeURIComponent(include)}`, {
         cache: "no-store",
       });
       if (!res.ok) {
-        const e = await res.json().catch(() => ({}));
-        throw new Error(e?.error || `Erro HTTP ${res.status}`);
+        const e = await res.json().catch((): { error?: string } => ({}));
+        throw new Error(e.error || `Erro HTTP ${res.status}`);
       }
       const data: Ticket = await res.json();
 
@@ -160,11 +184,10 @@ export default function AdminChamadoPage() {
       setStatus(data.status);
       setPrioridade(data.prioridade);
       setNivel(data.nivel);
-      setResponsavelId((data as any).responsavelId ?? data.responsavel?.id ?? "");
+      setResponsavelId(data.responsavelId ?? data.responsavel?.id ?? "");
 
       fetchAnexos(data.id);
-    } catch (e: any) {
-      setErr(e?.message || "Falha ao carregar");
+    } catch {
       setTicket(null);
     } finally {
       setLoading(false);
@@ -240,13 +263,14 @@ export default function AdminChamadoPage() {
         body: JSON.stringify(body),
       });
       if (!res.ok) {
-        const e = await res.json().catch(() => ({}));
-        throw new Error(e?.error || `Erro HTTP ${res.status}`);
+        const e = await res.json().catch((): { error?: string } => ({}));
+        throw new Error(e.error || `Erro HTTP ${res.status}`);
       }
       toast.success("Alterações salvas!");
       await load();
-    } catch (e: any) {
-      toast.error("Falha ao salvar", { description: e?.message });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Erro desconhecido";
+      toast.error("Falha ao salvar", { description: message });
     } finally {
       setSaving(false);
     }
@@ -261,8 +285,8 @@ export default function AdminChamadoPage() {
         body: JSON.stringify({ conteudo: msg.trim() }),
       });
       if (!res.ok) {
-        const e = await res.json().catch(() => ({}));
-        throw new Error(e?.error || `Erro HTTP ${res.status}`);
+        const e = await res.json().catch((): { error?: string } => ({}));
+        throw new Error(e.error || `Erro HTTP ${res.status}`);
       }
       const nova = await res.json();
 
@@ -275,8 +299,9 @@ export default function AdminChamadoPage() {
 
       setMsg("");
       endRef.current?.scrollIntoView({ behavior: "smooth" });
-    } catch (e: any) {
-      toast.error("Falha ao enviar mensagem", { description: e?.message });
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : "Erro desconhecido";
+      toast.error("Falha ao enviar mensagem", { description: message });
     } finally {
       setSending(false);
     }
@@ -304,9 +329,10 @@ export default function AdminChamadoPage() {
       setSelectedFile(null);
       if (fileInputRef.current) fileInputRef.current.value = "";
       await fetchAnexos(ticket.id);
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro desconhecido";
       console.error("Erro no upload:", err);
-      toast.error("Falha ao enviar arquivo.", { description: err.message });
+      toast.error("Falha ao enviar arquivo.", { description: message });
     } finally {
       setUploading(false);
     }
@@ -351,7 +377,7 @@ export default function AdminChamadoPage() {
             <h1 className="font-grotesk text-xl sm:text-2xl font-semibold tracking-tight line-clamp-2">
               {ticket.titulo}
             </h1>
-            <p className="mt-2 text-sm text-muted-foreground whitespace-pre-wrap">{ticket.descricao}</p>
+            <p className="mt-2 text-sm text-muted-foreground whitespace-pre-wrap">{ticket.descricao || "—"}</p>
           </div>
           <div className="flex flex-wrap items-center gap-2 flex-shrink-0 pt-1">
             <TicketStatusBadge status={ticket.status} />
@@ -394,13 +420,47 @@ export default function AdminChamadoPage() {
             <Clock className="size-4 flex-shrink-0 text-muted-foreground" />
             <span className="text-muted-foreground">Atualizado:</span>
             <span className="font-medium truncate">
-              {new Date(ticket.atualizadoEm).toLocaleString("pt-BR", {
-                day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit",
-              })}
+              {formatDateTimeOptional(ticket.atualizadoEm)}
             </span>
           </div>
         </div>
       </div>
+
+      <section className="rounded-xl border border-[var(--border)] bg-card p-4 mb-6">
+        <div className="flex items-center gap-2 mb-3">
+          <Building2 className="size-4 text-[var(--brand-red)]" />
+          <h2 className="font-semibold">Dados acadêmicos</h2>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-3 text-sm">
+          <InfoItem label="Unidade Fatec" value={ticket.unidadeFatec} />
+          <InfoItem label="Curso" value={ticket.curso} />
+          <InfoItem label="Turno" value={ticket.turno} />
+          <InfoItem label="Turma" value={ticket.turma} />
+          <InfoItem label="Semestre" value={ticket.semestre} />
+          <InfoItem label="Matriz curricular" value={ticket.matrizCurricular} />
+          <InfoItem label="Processo acadêmico" value={ticket.processoAcademico} />
+          <InfoItem label="Categoria acadêmica" value={ticket.categoriaAcademica} />
+          <InfoItem label="Impacto para o aluno" value={ticket.impactoAluno} />
+          <InfoItem label="Prazo relacionado" value={ticket.prazoAcademicoRelacionado} />
+          <InfoItem label="Data limite acadêmica" value={formatDateTimeOptional(ticket.dataLimiteAcademica)} />
+          <InfoItem label="Canal preferencial" value={ticket.canalPreferencialResposta} />
+          <InfoItem label="Setor atual" value={ticket.setorAtual ?? ticket.setor?.nome} />
+          <InfoItem label="Responsável atual" value={ticket.responsavelAtual ?? ticket.responsavel?.nome} />
+          <InfoItem label="Serviço ID" value={ticket.servicoId ?? ticket.servico?.id} />
+          <InfoItem label="Documentos obrigatórios" value={ticket.documentosObrigatorios} />
+          <InfoItem label="Documentos pendentes" value={ticket.documentosPendentes} />
+          <InfoItem label="SLA" value={ticket.slaHoras ? `${ticket.slaHoras}h` : ticket.slaDias ? `${ticket.slaDias} dia(s)` : null} />
+          <InfoItem label="Vencimento SLA" value={formatDateTimeOptional(ticket.vencimentoSla)} />
+        </div>
+
+        {(ticket.motivoEncaminhamento || ticket.observacaoInterna) && (
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+            <InfoItem label="Motivo do encaminhamento" value={ticket.motivoEncaminhamento} multiline />
+            <InfoItem label="Observação interna" value={ticket.observacaoInterna} multiline />
+          </div>
+        )}
+      </section>
 
       {/* layout: chat/anexos à esquerda, gestão/histórico à direita */}
       <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">

--- a/app/(dashboard)/admin/chamados/page.tsx
+++ b/app/(dashboard)/admin/chamados/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Search, Filter, LayoutList, LayoutGrid, ChevronRight,
-  Tag, User, Building2, Clock, ArrowUpDown
+  Tag, User, Clock, ArrowUpDown
 } from "lucide-react";
 import { apiFetch } from "../../../../utils/api";
 import Link from "next/link";
@@ -13,11 +13,9 @@ import TicketStatusBadge from "../../../components/shared/TicketStatusBadge";
 import PriorityDot from "../../../components/shared/PriorityDot";
 import NivelBadge from "../../../components/shared/NivelBadge";
 import SetorChip from "../../../components/shared/SetorChip";
+import type { Chamado, Nivel, PageResponse, Prioridade, Status } from "../../../../utils/types";
 
 /* ===== Tipos ===== */
-type Status = "ABERTO" | "EM_ATENDIMENTO" | "AGUARDANDO_USUARIO" | "RESOLVIDO" | "ENCERRADO";
-type Prioridade = "BAIXA" | "MEDIA" | "ALTA" | "URGENTE";
-type Nivel = "N1" | "N2" | "N3";
 
 type ChamadoUI = {
   id: string;
@@ -30,28 +28,14 @@ type ChamadoUI = {
   solicitante: string;
   responsavel?: string | null;
   setor?: string | null;
+  curso?: string | null;
+  unidadeFatec?: string | null;
+  processoAcademico?: string | null;
 };
 
-type ApiChamado = {
-  id: string;
-  protocolo?: string | null;
-  titulo: string;
-  descricao?: string | null;
-  nivel: Nivel;
-  status: Status;
-  prioridade: Prioridade;
-  criadoEm: string;
-  criadoPor?: { nome?: string | null } | null;
-  responsavel?: { nome?: string | null } | null;
-  setor?: { nome?: string | null } | null;
-};
+type ApiChamado = Chamado & { nivel: Nivel; prioridade: Prioridade };
 
-type PageResp = {
-  total: number;
-  page: number;
-  pageSize: number;
-  items: ApiChamado[];
-};
+type PageResp = PageResponse<ApiChamado>;
 
 function toUI(x: ApiChamado): ChamadoUI {
   return {
@@ -64,7 +48,10 @@ function toUI(x: ApiChamado): ChamadoUI {
     nivel: x.nivel,
     solicitante: x.criadoPor?.nome || "—",
     responsavel: x.responsavel?.nome || null,
-    setor: x.setor?.nome || null,
+    setor: x.setor?.nome || x.setorAtual || null,
+    curso: x.curso || null,
+    unidadeFatec: x.unidadeFatec || null,
+    processoAcademico: x.processoAcademico || null,
   };
 }
 
@@ -119,8 +106,9 @@ export default function AdminChamadosPage() {
         const data: PageResp = await res.json();
         const items = (data?.items ?? []).map(toUI);
         if (alive) setDadosApi(items);
-      } catch (e: any) {
-        if (alive) setError(e?.message || "Falha ao carregar chamados");
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : "Falha ao carregar chamados";
+        if (alive) setError(message);
       } finally {
         if (alive) setLoading(false);
       }
@@ -147,7 +135,10 @@ export default function AdminChamadosPage() {
         c.titulo.toLowerCase().includes(ql) ||
         (c.protocolo ?? "").toLowerCase().includes(ql) ||
         c.solicitante.toLowerCase().includes(ql) ||
-        (c.responsavel ?? "").toLowerCase().includes(ql);
+        (c.responsavel ?? "").toLowerCase().includes(ql) ||
+        (c.curso ?? "").toLowerCase().includes(ql) ||
+        (c.unidadeFatec ?? "").toLowerCase().includes(ql) ||
+        (c.processoAcademico ?? "").toLowerCase().includes(ql);
       const matchS = status === "ALL" || c.status === status;
       const matchP = prioridade === "ALL" || c.prioridade === prioridade;
       const matchN = nivel === "ALL" || c.nivel === nivel;
@@ -184,7 +175,7 @@ export default function AdminChamadosPage() {
                 <select
                   className="h-10 w-[190px] pl-9 pr-8 rounded-lg border border-[var(--border)] bg-background focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                   value={status}
-                  onChange={(e) => setStatus(e.target.value as any)}
+                  onChange={(e) => setStatus(e.target.value as Status | "ALL")}
                 >
                   <option value="ALL">Todos os status</option>
                   <option value="ABERTO">Aberto</option>
@@ -198,7 +189,7 @@ export default function AdminChamadosPage() {
               <select
                 className="h-10 w-[160px] px-3 rounded-lg border border-[var(--border)] bg-background focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                 value={prioridade}
-                onChange={(e) => setPrioridade(e.target.value as any)}
+                onChange={(e) => setPrioridade(e.target.value as Prioridade | "ALL")}
               >
                 <option value="ALL">Todas as prioridades</option>
                 <option value="BAIXA">Baixa</option>
@@ -210,7 +201,7 @@ export default function AdminChamadosPage() {
               <select
                 className="h-10 w-[120px] px-3 rounded-lg border border-[var(--border)] bg-background focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                 value={nivel}
-                onChange={(e) => setNivel(e.target.value as any)}
+                onChange={(e) => setNivel(e.target.value as Nivel | "ALL")}
               >
                 <option value="ALL">Nível (todos)</option>
                 <option value="N1">N1</option>
@@ -221,7 +212,7 @@ export default function AdminChamadosPage() {
               <select
                 className="h-10 w-[180px] px-3 rounded-lg border border-[var(--border)] bg-background focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                 value={setor}
-                onChange={(e) => setSetor(e.target.value as any)}
+                onChange={(e) => setSetor(e.target.value)}
               >
                 <option value="ALL">Todos os setores</option>
                 {setoresDisponiveis.map((s) => (
@@ -310,6 +301,11 @@ function Lista({ dados, sortDesc, setSortDesc }: {
                 <td className="px-4 py-3 font-medium">{c.protocolo ?? `#${c.id}`}</td>
                 <td className="px-4 py-3 max-w-[380px]">
                   <div className="line-clamp-1">{c.titulo}</div>
+                  {(c.curso || c.unidadeFatec) && (
+                    <div className="mt-1 text-xs text-muted-foreground line-clamp-1">
+                      {[c.curso, c.unidadeFatec].filter(Boolean).join(" · ")}
+                    </div>
+                  )}
                   <div className="md:hidden mt-1 flex items-center gap-2 text-xs text-muted-foreground">
                     <SetorChip nome={c.setor} />
                     <span className="inline-flex items-center gap-1">
@@ -406,6 +402,11 @@ function CardKanban({ c }: { c: ChamadoUI }) {
           <div className="font-medium leading-tight line-clamp-2">
             {c.titulo}
           </div>
+          {(c.curso || c.unidadeFatec) && (
+            <div className="mt-1 text-xs text-muted-foreground line-clamp-1">
+              {[c.curso, c.unidadeFatec].filter(Boolean).join(" · ")}
+            </div>
+          )}
         </div>
         <NivelBadge nivel={c.nivel} />
       </div>

--- a/app/(dashboard)/aluno/chamados/[id]/page.tsx
+++ b/app/(dashboard)/aluno/chamados/[id]/page.tsx
@@ -15,9 +15,9 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { apiFetch } from "../../../../../utils/api";
+import type { Chamado, Status } from "../../../../../utils/types";
 
 /* ================= Tipos ================= */
-type Status = "ABERTO" | "EM_ATENDIMENTO" | "AGUARDANDO_USUARIO" | "RESOLVIDO" | "ENCERRADO";
 
 const STATUS_LABELS: Record<Status, string> = {
   ABERTO: "Solicitação recebida pela Fatec.",
@@ -25,16 +25,6 @@ const STATUS_LABELS: Record<Status, string> = {
   AGUARDANDO_USUARIO: "Aguardando documento ou resposta do aluno.",
   RESOLVIDO: "Solicitação respondida.",
   ENCERRADO: "Atendimento finalizado.",
-};
-
-type Chamado = {
-  id: string;
-  titulo: string;
-  descricao: string;
-  status: Status;
-  criadoEm: string;
-  protocolo?: string | null;
-  criadoPorId?: string | null;
 };
 
 type Mensagem = {
@@ -184,8 +174,9 @@ function confirmarReabertura() {
       if (!res.ok) throw new Error(`Erro ${res.status}`);
       const data: Chamado = await res.json();
       setChamado(data);
-    } catch (err: any) {
-      toast.error(err.message || "Erro ao carregar solicitação acadêmica.");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro ao carregar solicitação acadêmica.";
+      toast.error(message);
     } finally {
       setLoading(false);
     }
@@ -207,8 +198,9 @@ function confirmarReabertura() {
       lista.forEach((m) => knownIds.current.add(m.id));
       setMsgs(lista);
       scrollToEnd(false);
-    } catch (err: any) {
-      toast.error(err.message || "Erro ao carregar mensagens.");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro ao carregar mensagens.";
+      toast.error(message);
     } finally {
       setMsgLoading(false);
     }
@@ -272,8 +264,9 @@ function confirmarReabertura() {
       }
       setMsgText("");
       scrollToEnd();
-    } catch (err: any) {
-      toast.error(err.message || "Erro ao enviar mensagem.");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro ao enviar mensagem.";
+      toast.error(message);
     } finally {
       setMsgSending(false);
     }
@@ -288,8 +281,9 @@ function confirmarReabertura() {
       if (!res.ok) throw new Error(`Erro ${res.status}`);
       const data = await res.json();
       setAnexos(Array.isArray(data) ? data : []);
-    } catch (err: any) {
-      toast.error(err.message || "Erro ao carregar anexos.");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro ao carregar anexos.";
+      toast.error(message);
     } finally {
       setLoadingAnexos(false);
     }
@@ -317,8 +311,9 @@ function confirmarReabertura() {
       setSelectedFile(null);
       if (fileInputRef.current) fileInputRef.current.value = "";
       await fetchAnexos(chamado.id);
-    } catch (err: any) {
-      toast.error(err.message || "Falha ao enviar arquivo.");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Falha ao enviar arquivo.";
+      toast.error(message);
     } finally {
       setUploading(false);
     }
@@ -339,8 +334,9 @@ function confirmarReabertura() {
           : "Solicitação acadêmica finalizada com sucesso."
       );
       await fetchChamado();
-    } catch (err: any) {
-      toast.error("Erro ao atualizar status", { description: err.message });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Erro desconhecido";
+      toast.error("Erro ao atualizar status", { description: message });
     }
   }
 
@@ -391,7 +387,7 @@ function confirmarReabertura() {
         <div className="space-y-2 text-sm border-t border-b py-4">
           <p>
             <strong>Descrição:</strong>{" "}
-            <span className="whitespace-pre-wrap">{chamado.descricao}</span>
+            <span className="whitespace-pre-wrap">{chamado.descricao || "—"}</span>
           </p>
           <p>
             <strong>Status:</strong> {STATUS_LABELS[chamado.status] ?? chamado.status}

--- a/app/(dashboard)/aluno/chamados/page.tsx
+++ b/app/(dashboard)/aluno/chamados/page.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import {
   Search,
   AlertTriangle,
-  ChevronRight,
   Paperclip,
   Plus,
   Loader2,
@@ -16,32 +15,9 @@ import MobileSidebarTriggerAluno from "../_components/MobileSidebarTriggerAluno"
 import { apiFetch } from "../../../../utils/api";
 import { cx } from '../../../../utils/cx'
 import TicketStatusBadge from "../../../components/shared/TicketStatusBadge";
+import type { Chamado, PageResponse, Status } from "../../../../utils/types";
 
-/* ---------- Tipos ---------- */
-type Status =
-  | "ABERTO"
-  | "EM_ATENDIMENTO"
-  | "AGUARDANDO_USUARIO"
-  | "RESOLVIDO"
-  | "ENCERRADO";
-
-type Chamado = {
-  id: string;
-  protocolo?: string | null;
-  titulo: string;
-  criadoEm: string;
-  status: Status;
-  setor?: { nome?: string | null } | null;
-  precisaAcaoDoAluno?: boolean | null;
-  mensagensNaoLidas?: number | null;
-};
-
-type PageResp = {
-  total: number;
-  page: number;
-  pageSize: number;
-  items: Chamado[];
-};
+type PageResp = PageResponse<Chamado>;
 
 
 function AcoesChamado({ c }: { c: Chamado }) {
@@ -108,8 +84,9 @@ export default function MeusChamadosPage() {
         }
         const data: PageResp = await res.json();
         if (alive) setDados(data.items ?? []);
-      } catch (err: any) {
-        toast.error("Erro ao carregar solicitações acadêmicas", { description: err?.message });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : undefined;
+        toast.error("Erro ao carregar solicitações acadêmicas", { description: message });
       } finally {
         if (alive) setLoading(false);
       }
@@ -197,7 +174,7 @@ export default function MeusChamadosPage() {
           <select
             className="h-10 w-full sm:w-[200px] px-3 rounded-lg border border-[var(--border)] bg-background focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
             value={status}
-            onChange={(e) => setStatus(e.target.value as any)}
+            onChange={(e) => setStatus(e.target.value as Status | "ALL")}
           >
             <option value="ALL">Todos os status</option>
             <option value="ABERTO">Solicitação recebida pela Fatec.</option>

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -9,15 +9,63 @@ export type Prioridade = "BAIXA" | "MEDIA" | "ALTA" | "URGENTE";
 
 export type Papel = "USUARIO" | "BACKOFFICE" | "TECNICO" | "ADMINISTRADOR";
 
-export type Chamado = {
+export type Nivel = "N1" | "N2" | "N3";
+
+export type UsuarioMin = {
+  id: string;
+  nome?: string | null;
+  emailPessoal?: string | null;
+  ra?: string | null;
+};
+
+export type SetorMin = { id?: string | null; nome?: string | null };
+export type ServicoMin = { id?: string | null; nome?: string | null };
+
+export type TicketCamposAcademicos = {
+  unidadeFatec?: string | null;
+  curso?: string | null;
+  turno?: string | null;
+  turma?: string | null;
+  semestre?: string | number | null;
+  matrizCurricular?: string | null;
+  processoAcademico?: string | null;
+  categoriaAcademica?: string | null;
+  servicoId?: string | null;
+  impactoAluno?: string | null;
+  prazoAcademicoRelacionado?: string | null;
+  dataLimiteAcademica?: string | null;
+  canalPreferencialResposta?: string | null;
+  setorAtual?: string | null;
+  responsavelAtual?: string | null;
+  motivoEncaminhamento?: string | null;
+  observacaoInterna?: string | null;
+  documentosObrigatorios?: string[] | string | null;
+  documentosPendentes?: string[] | string | null;
+  slaHoras?: number | string | null;
+  slaDias?: number | string | null;
+  vencimentoSla?: string | null;
+};
+
+export type Chamado = TicketCamposAcademicos & {
   id: string;
   protocolo?: string | null;
   titulo: string;
   criadoEm: string;
   status: Status;
   prioridade: Prioridade;
-  setor?: { nome?: string | null } | null;
-  criadoPor?: { nome?: string | null } | null;
+  nivel?: Nivel | null;
+  descricao?: string | null;
+  atualizadoEm?: string | null;
+  encerradoEm?: string | null;
+  criadoPorId?: string | null;
+  responsavelId?: string | null;
+  setor?: SetorMin | null;
+  criadoPor?: UsuarioMin | null;
+  aluno?: UsuarioMin | null;
+  responsavel?: UsuarioMin | null;
+  servico?: ServicoMin | null;
+  precisaAcaoDoAluno?: boolean | null;
+  mensagensNaoLidas?: number | null;
 };
 
 export type PageResponse<T> = {


### PR DESCRIPTION
### Motivation
- Expand the ticket (chamado) model on the frontend to include the requested academic fields while keeping full compatibility with older tickets that lack them. 
- Surface relevant academic data for secretaria/admin in the ticket detail UI so staff can see course/unit/process information without backend changes in this PR.

### Description
- Add shared types and academic fields to `utils/types.ts` (new `TicketCamposAcademicos`, `Chamado` extension, `UsuarioMin`, `SetorMin`, `ServicoMin`, `Nivel`), keeping all new fields optional to support older tickets. 
- Update student pages to consume the shared types: `app/(dashboard)/aluno/chamados/page.tsx` and `app/(dashboard)/aluno/chamados/[id]/page.tsx` now import `Chamado`/`Status` from `utils/types.ts` and render defensive fallbacks for missing values. 
- Update admin list/detail pages to use the new types and show academic info: `app/(dashboard)/admin/chamados/page.tsx` now maps incoming items into a UI model that includes `curso`, `unidadeFatec`, `processoAcademico` and enables searching by those fields; `app/(dashboard)/admin/chamados/[id]/page.tsx` now requests `aluno` in the `include` parameter, uses helper formatters and displays a new “Dados acadêmicos” section with the requested fields and safe fallbacks. 
- Add small robustness improvements: safer `catch` handling (treat `unknown` errors), `formatOptional` / `formatDateTimeOptional` helpers and `InfoItem` UI helper used by the admin detail screen. 
- Note: backend migration/relationship/schema and API endpoint changes are not included here because this repository contains only the frontend; the frontend changes assume the backend will provide the corresponding fields/relations (they remain optional so old tickets work).

### Testing
- Ran focused lint on modified files: `npx eslint 'app/(dashboard)/admin/chamados/page.tsx' 'app/(dashboard)/admin/chamados/[id]/page.tsx' 'app/(dashboard)/aluno/chamados/page.tsx' 'app/(dashboard)/aluno/chamados/[id]/page.tsx' utils/types.ts` which passed for those files (global repo lint had preexisting errors outside the scope of this change). 
- Type-check: `pnpm exec tsc --noEmit` succeeded with no new type errors. 
- Production build: `pnpm build` failed in this environment due to inability to fetch Google fonts used by `next/font` (network/font fetch issue), unrelated to the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd368ba75c832e86acb81a9e73b717)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nova seção "Dados acadêmicos" nos detalhes do chamado com informações de curso, unidade e processo.
  * Busca e filtros expandidos para incluir campos acadêmicos (curso, unidade, processo).
  * Exibição condicional de curso e unidade na lista de chamados.

* **Improvements**
  * Melhor formatação de datas e valores vazios nos chamados.
  * Tratamento de erros padronizado em operações do sistema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->