### PR TITLE
Add service-specific academic request forms and validation

### DIFF
--- a/app/(dashboard)/aluno/catalogo/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/page.tsx
@@ -1,17 +1,46 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Search, Layers, BookOpen, Plus, Loader2 } from "lucide-react";
+import { Search, Layers, BookOpen, Plus, Loader2, X } from "lucide-react";
 import MobileSidebarTriggerAluno from "../_components/MobileSidebarTriggerAluno";
 import { CATALOGO_INSTITUCIONAL, type CatalogResponse, type ServicoCatalogo } from "../../../../utils/catalogo";
 import { cx } from "../../../../utils/cx";
+import {
+  getServiceFormConfig,
+  validateServicePayload,
+  type ServiceFormConfig,
+  type ServiceFormField,
+  type ServiceFormValues,
+} from "../../../../utils/serviceForms";
 
 type Servico = ServicoCatalogo & { categoriaNome?: string };
+type FormErrors = Record<string, string>;
 
 function getErrorMessage(err: unknown, fallback: string) {
   return err instanceof Error ? err.message : fallback;
+}
+
+function getInitialValues(config: ServiceFormConfig): ServiceFormValues {
+  return config.campos.reduce<ServiceFormValues>((acc, campo) => {
+    acc[campo.id] = campo.tipo === "checkbox" ? false : campo.tipo === "arquivo" ? [] : "";
+    return acc;
+  }, {});
+}
+
+function formatFieldValue(campo: ServiceFormField, value: ServiceFormValues[string]) {
+  if (campo.tipo === "checkbox") return value ? "Sim" : "Não";
+  if (Array.isArray(value)) return value.join(", ");
+  return String(value ?? "");
+}
+
+function buildTicketDescription(servico: Servico, config: ServiceFormConfig, values: ServiceFormValues) {
+  const detalhes = config.campos
+    .map((campo) => `- ${campo.label}: ${formatFieldValue(campo, values[campo.id]) || "Não informado"}`)
+    .join("\n");
+
+  return `${servico.descricao || "Solicitação aberta via catálogo"}\n\nDados do formulário:\n${detalhes}`;
 }
 
 /* ----------------------------- MOCK (fallback) ----------------------------- */
@@ -32,28 +61,137 @@ function CategoriaPill({ label, active, onClick }: { label: string; active?: boo
   );
 }
 
-/* ----------------------------- Card de Serviço ----------------------------- */
-function ServicoCard({ s }: { s: Servico }) {
+function FormField({
+  campo,
+  value,
+  error,
+  onChange,
+}: {
+  campo: ServiceFormField;
+  value: ServiceFormValues[string];
+  error?: string;
+  onChange: (id: string, value: ServiceFormValues[string]) => void;
+}) {
+  const baseClass = cx(
+    "w-full rounded-lg border bg-input px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
+    error ? "border-red-500" : "border-[var(--border)]"
+  );
+
+  function handleTextChange(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) {
+    onChange(campo.id, e.target.value);
+  }
+
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    onChange(campo.id, Array.from(e.target.files ?? []).map((file) => file.name));
+  }
+
+  return (
+    <label className={cx("block", campo.tipo === "checkbox" && "flex items-start gap-3 rounded-lg border border-[var(--border)] p-3")}>
+      {campo.tipo === "checkbox" ? (
+        <input
+          type="checkbox"
+          className="mt-1 size-4 accent-[var(--primary)]"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(campo.id, e.target.checked)}
+        />
+      ) : null}
+
+      <span className="block flex-1">
+        <span className="mb-1 block text-sm font-medium">
+          {campo.label} {campo.obrigatorio && <span className="text-red-500">*</span>}
+        </span>
+
+        {campo.tipo === "textarea" && (
+          <textarea className={cx(baseClass, "min-h-24 resize-y")} value={String(value ?? "")} placeholder={campo.placeholder} onChange={handleTextChange} />
+        )}
+
+        {campo.tipo === "select" && (
+          <select className={baseClass} value={String(value ?? "")} onChange={handleTextChange}>
+            <option value="">Selecione uma opção</option>
+            {campo.opcoes?.map((opcao) => (
+              <option key={opcao.value} value={opcao.value}>
+                {opcao.label}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {campo.tipo === "arquivo" && (
+          <input type="file" className={baseClass} accept={campo.accept} onChange={handleFileChange} />
+        )}
+
+        {(campo.tipo === "texto" || campo.tipo === "data" || campo.tipo === "numero") && (
+          <input
+            type={campo.tipo === "data" ? "date" : campo.tipo === "numero" ? "number" : "text"}
+            step={campo.tipo === "numero" ? "any" : undefined}
+            className={baseClass}
+            value={String(value ?? "")}
+            placeholder={campo.placeholder}
+            onChange={handleTextChange}
+          />
+        )}
+
+        {campo.ajuda && <span className="mt-1 block text-xs text-muted-foreground">{campo.ajuda}</span>}
+        {error && <span className="mt-1 block text-xs text-red-500">{error}</span>}
+      </span>
+    </label>
+  );
+}
+
+function ServiceRequestModal({ servico, onClose }: { servico: Servico; onClose: () => void }) {
   const router = useRouter();
+  const config = getServiceFormConfig(servico.id);
+  const [values, setValues] = useState<ServiceFormValues>(() => (config ? getInitialValues(config) : {}));
+  const [errors, setErrors] = useState<FormErrors>({});
   const [loading, setLoading] = useState(false);
 
-  async function handleAbrirSolicitacao() {
-    if (!s.ativo) return;
+  const validation = useMemo(
+    () => (config ? validateServicePayload(servico.id, values) : { valid: true as const, values }),
+    [config, servico.id, values]
+  );
+
+  if (!config) return null;
+  const activeConfig = config;
+
+  function updateField(id: string, value: ServiceFormValues[string]) {
+    setValues((current) => ({ ...current, [id]: value }));
+    setErrors((current) => {
+      if (!current[id]) return current;
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const currentValidation = validateServicePayload(servico.id, values);
+    if (!currentValidation.valid) {
+      setErrors(currentValidation.errors);
+      toast.error("Preencha os campos obrigatórios antes de enviar.");
+      return;
+    }
+
     try {
       setLoading(true);
       const token = localStorage.getItem("accessToken");
       if (!token) throw new Error("Sessão expirada. Faça login novamente.");
 
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/tickets`, {
+      const res = await fetch("/tickets", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          titulo: s.nome,
-          descricao: s.descricao || "Solicitação aberta via catálogo",
-          servicoId: s.id,
+          titulo: servico.nome,
+          descricao: buildTicketDescription(servico, activeConfig, values),
+          servicoId: servico.id,
+          formulario: {
+            servicoId: servico.id,
+            versao: 1,
+            campos: values,
+          },
           nivel: "N1",
           prioridade: "MEDIA",
         }),
@@ -75,15 +213,67 @@ function ServicoCard({ s }: { s: Servico }) {
   }
 
   return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="max-h-[90vh] w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-card shadow-xl">
+        <div className="flex items-start justify-between gap-4 border-b border-[var(--border)] p-5">
+          <div>
+            <h2 className="font-grotesk text-xl font-semibold tracking-tight">{activeConfig.titulo}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{activeConfig.descricao}</p>
+          </div>
+          <button className="rounded-md p-1 hover:bg-[var(--muted)]" onClick={onClose} aria-label="Fechar formulário">
+            <X className="size-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="max-h-[calc(90vh-96px)] overflow-y-auto p-5">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {activeConfig.campos.map((campo) => (
+              <div key={campo.id} className={cx((campo.tipo === "textarea" || campo.tipo === "arquivo") && "sm:col-span-2")}>
+                <FormField campo={campo} value={values[campo.id]} error={errors[campo.id]} onChange={updateField} />
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 flex flex-col-reverse gap-2 border-t border-[var(--border)] pt-4 sm:flex-row sm:items-center sm:justify-end">
+            <button type="button" onClick={onClose} className="h-10 rounded-md border border-[var(--border)] px-4 text-sm hover:bg-[var(--muted)]">
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !validation.valid}
+              className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {loading && <Loader2 className="size-4 animate-spin" />}
+              Enviar solicitação
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------- Card de Serviço ----------------------------- */
+function ServicoCard({ s, onSelect }: { s: Servico; onSelect: (servico: Servico) => void }) {
+  const hasForm = Boolean(getServiceFormConfig(s.id));
+
+  return (
     <div className="rounded-xl border border-[var(--border)] bg-card p-4 flex flex-col justify-between">
       <div className="mb-4">
         <div className="flex items-start justify-between gap-3">
           <h3 className="font-medium leading-tight">{s.nome}</h3>
-          {!s.ativo && (
-            <span className="text-[10px] px-2 py-0.5 rounded-full border border-[var(--border)] bg-[var(--muted)] text-muted-foreground">
-              Indisponível
-            </span>
-          )}
+          <div className="flex flex-col items-end gap-1">
+            {!s.ativo && (
+              <span className="text-[10px] px-2 py-0.5 rounded-full border border-[var(--border)] bg-[var(--muted)] text-muted-foreground">
+                Indisponível
+              </span>
+            )}
+            {hasForm && (
+              <span className="text-[10px] px-2 py-0.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 text-emerald-600">
+                Formulário ativo
+              </span>
+            )}
+          </div>
         </div>
         {s.descricao && (
           <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{s.descricao}</p>
@@ -93,24 +283,17 @@ function ServicoCard({ s }: { s: Servico }) {
       <div className="flex items-center justify-between">
         <div className="text-xs text-muted-foreground">ID: {s.id}</div>
         <button
-          disabled={!s.ativo || loading}
-          onClick={handleAbrirSolicitacao}
+          disabled={!s.ativo || !hasForm}
+          onClick={() => onSelect(s)}
           className={cx(
             "inline-flex items-center gap-1.5 h-9 px-3 rounded-md text-sm transition",
-            s.ativo
+            s.ativo && hasForm
               ? "bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-60"
               : "bg-[var(--muted)] text-muted-foreground cursor-not-allowed"
           )}
+          title={hasForm ? "Iniciar solicitação" : "Formulário ainda não disponível"}
         >
-          {loading ? (
-            <>
-              <Loader2 className="size-4 animate-spin" /> Abrindo...
-            </>
-          ) : (
-            <>
-              <Plus className="size-4" /> Iniciar solicitação
-            </>
-          )}
+          <Plus className="size-4" /> Iniciar solicitação
         </button>
       </div>
     </div>
@@ -123,6 +306,7 @@ export default function CatalogoAlunoPage() {
   const [catalog, setCatalog] = useState<CatalogResponse>(MOCK);
   const [q, setQ] = useState("");
   const [catId, setCatId] = useState<string | "ALL">("ALL");
+  const [selectedService, setSelectedService] = useState<Servico | null>(null);
 
 
   /* Buscar catálogo */
@@ -171,7 +355,7 @@ export default function CatalogoAlunoPage() {
 
   const kpis = useMemo(() => {
     const total = flatServicos.length;
-    const ativos = flatServicos.filter((s) => s.ativo).length;
+    const ativos = flatServicos.filter((s) => s.ativo && Boolean(getServiceFormConfig(s.id))).length;
     const indisponiveis = total - ativos;
     return { total, ativos, indisponiveis };
   }, [flatServicos]);
@@ -179,6 +363,8 @@ export default function CatalogoAlunoPage() {
   /* ----------------------------- Render ----------------------------- */
   return (
     <>
+      {selectedService && <ServiceRequestModal servico={selectedService} onClose={() => setSelectedService(null)} />}
+
       {/* Topbar */}
       <div className="mb-6 flex items-center justify-between">
         <div>
@@ -247,7 +433,7 @@ export default function CatalogoAlunoPage() {
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
             {filtrados.map((s) => (
-              <ServicoCard key={s.id} s={s} />
+              <ServicoCard key={s.id} s={s} onSelect={setSelectedService} />
             ))}
           </div>
         )}

--- a/app/tickets/route.ts
+++ b/app/tickets/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateServicePayload, type ServiceFormValues } from "../../utils/serviceForms";
+
+const API_BASE = process.env.API_BASE_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+type TicketPayload = {
+  servicoId?: string;
+  formulario?: {
+    campos?: ServiceFormValues;
+  };
+};
+
+export async function POST(req: NextRequest) {
+  const payload = (await req.json()) as TicketPayload;
+  const servicoId = payload.servicoId;
+
+  if (!servicoId) {
+    return NextResponse.json({ message: "servicoId é obrigatório para abrir uma solicitação acadêmica." }, { status: 400 });
+  }
+
+  const validation = validateServicePayload(servicoId, payload.formulario?.campos ?? {});
+  if (!validation.valid) {
+    return NextResponse.json(
+      {
+        message: "Solicitação incompleta. Verifique os campos obrigatórios do formulário.",
+        errors: validation.errors,
+      },
+      { status: 400 }
+    );
+  }
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: "Backend de tickets não configurado." }, { status: 503 });
+  }
+
+  const authorization = req.headers.get("authorization");
+  const res = await fetch(`${API_BASE}/tickets`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...(authorization ? { Authorization: authorization } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/utils/catalogo.ts
+++ b/utils/catalogo.ts
@@ -1,7 +1,9 @@
+import { getServiceFormConfig } from "./serviceForms";
+
 export type FormularioCampo = {
   id: string;
   label: string;
-  tipo: "texto" | "textarea" | "select" | "arquivo" | "data";
+  tipo: "texto" | "textarea" | "select" | "arquivo" | "data" | "checkbox" | "numero";
   obrigatorio: boolean;
   opcoes?: string[];
   ajuda?: string;
@@ -59,6 +61,8 @@ function servico(
   palavrasChave: string[],
   ativo = true
 ): ServicoCatalogo {
+  const formConfig = getServiceFormConfig(id);
+
   return {
     id,
     nome,
@@ -66,7 +70,20 @@ function servico(
     ativo,
     categoriaId,
     palavrasChave: [...palavrasChave, ...fatecKeywords],
-    formulario: FORMULARIO_FUTURO,
+    formulario: formConfig
+      ? {
+          versao: 1,
+          disponivel: true,
+          campos: formConfig.campos.map((campo) => ({
+            id: campo.id,
+            label: campo.label,
+            tipo: campo.tipo,
+            obrigatorio: campo.obrigatorio,
+            opcoes: campo.opcoes?.map((opcao) => opcao.label),
+            ajuda: campo.ajuda,
+          })),
+        }
+      : FORMULARIO_FUTURO,
   };
 }
 

--- a/utils/serviceForms.ts
+++ b/utils/serviceForms.ts
@@ -1,0 +1,258 @@
+export type ServiceFormFieldType = "texto" | "textarea" | "select" | "arquivo" | "data" | "checkbox" | "numero";
+
+export type ServiceFormOption = {
+  label: string;
+  value: string;
+};
+
+export type ServiceFormField = {
+  id: string;
+  label: string;
+  tipo: ServiceFormFieldType;
+  obrigatorio: boolean;
+  opcoes?: ServiceFormOption[];
+  ajuda?: string;
+  placeholder?: string;
+  accept?: string;
+};
+
+export type ServiceFormConfig = {
+  servicoId: string;
+  titulo: string;
+  descricao: string;
+  campos: ServiceFormField[];
+};
+
+export type ServiceFormValues = Record<string, string | boolean | string[]>;
+
+export type ServicePayloadValidationResult =
+  | { valid: true; values: ServiceFormValues }
+  | { valid: false; errors: Record<string, string> };
+
+const requiredMessage = (label: string) => `${label} é obrigatório.`;
+
+export const SERVICE_FORM_CONFIGS: Record<string, ServiceFormConfig> = {
+  "secretaria-declaracao-matricula": {
+    servicoId: "secretaria-declaracao-matricula",
+    titulo: "Formulário de Declaração de Matrícula",
+    descricao: "Informe como a declaração deve ser emitida para a Secretaria Acadêmica.",
+    campos: [
+      {
+        id: "finalidade",
+        label: "Finalidade",
+        tipo: "textarea",
+        obrigatorio: true,
+        placeholder: "Ex.: comprovação de vínculo para estágio, transporte, benefício estudantil...",
+      },
+      {
+        id: "destinatario",
+        label: "Destinatário",
+        tipo: "texto",
+        obrigatorio: true,
+        placeholder: "Ex.: Empresa, órgão público, instituição ou A quem interessar possa",
+      },
+      {
+        id: "incluirHorarioAulas",
+        label: "Incluir horário das aulas",
+        tipo: "checkbox",
+        obrigatorio: false,
+      },
+      {
+        id: "incluirPrevisaoConclusao",
+        label: "Incluir previsão de conclusão",
+        tipo: "checkbox",
+        obrigatorio: false,
+      },
+      {
+        id: "incluirCargaHoraria",
+        label: "Incluir carga horária",
+        tipo: "checkbox",
+        obrigatorio: false,
+      },
+      {
+        id: "formatoDesejado",
+        label: "Formato desejado",
+        tipo: "select",
+        obrigatorio: true,
+        opcoes: [
+          { label: "Digital (PDF)", value: "digital-pdf" },
+          { label: "Impresso para retirada", value: "impresso-retirada" },
+        ],
+      },
+    ],
+  },
+  "secretaria-historico-escolar": {
+    servicoId: "secretaria-historico-escolar",
+    titulo: "Formulário de Histórico Escolar",
+    descricao: "Detalhe o tipo de histórico necessário e o prazo desejado.",
+    campos: [
+      {
+        id: "finalidade",
+        label: "Finalidade",
+        tipo: "textarea",
+        obrigatorio: true,
+        placeholder: "Ex.: transferência, estágio, comprovação acadêmica, processo seletivo...",
+      },
+      {
+        id: "tipoHistorico",
+        label: "Tipo de histórico",
+        tipo: "select",
+        obrigatorio: true,
+        opcoes: [
+          { label: "Parcial", value: "parcial" },
+          { label: "Final", value: "final" },
+        ],
+      },
+      {
+        id: "precisaAssinaturaCarimbo",
+        label: "Precisa de assinatura/carimbo",
+        tipo: "checkbox",
+        obrigatorio: false,
+      },
+      {
+        id: "prazoDesejado",
+        label: "Prazo desejado",
+        tipo: "data",
+        obrigatorio: true,
+      },
+    ],
+  },
+  "secretaria-aproveitamento-estudos": {
+    servicoId: "secretaria-aproveitamento-estudos",
+    titulo: "Formulário de Aproveitamento de Estudos",
+    descricao: "Informe os dados da disciplina cursada e anexe a documentação obrigatória.",
+    campos: [
+      { id: "instituicaoOrigem", label: "Instituição de origem", tipo: "texto", obrigatorio: true },
+      { id: "cursoOrigem", label: "Curso de origem", tipo: "texto", obrigatorio: true },
+      { id: "disciplinaCursada", label: "Disciplina cursada", tipo: "texto", obrigatorio: true },
+      { id: "cargaHoraria", label: "Carga horária", tipo: "numero", obrigatorio: true, placeholder: "Ex.: 80" },
+      { id: "disciplinaPretendidaFatec", label: "Disciplina pretendida na Fatec", tipo: "texto", obrigatorio: true },
+      {
+        id: "historico",
+        label: "Histórico",
+        tipo: "arquivo",
+        obrigatorio: true,
+        accept: ".pdf,.jpg,.jpeg,.png",
+        ajuda: "Anexo obrigatório.",
+      },
+      {
+        id: "ementa",
+        label: "Ementa",
+        tipo: "arquivo",
+        obrigatorio: true,
+        accept: ".pdf,.doc,.docx,.jpg,.jpeg,.png",
+        ajuda: "Anexo obrigatório.",
+      },
+      {
+        id: "conteudoProgramatico",
+        label: "Conteúdo programático",
+        tipo: "arquivo",
+        obrigatorio: true,
+        accept: ".pdf,.doc,.docx,.jpg,.jpeg,.png",
+        ajuda: "Anexo obrigatório.",
+      },
+    ],
+  },
+  "secretaria-revisao-nota": {
+    servicoId: "secretaria-revisao-nota",
+    titulo: "Formulário de Revisão de Nota",
+    descricao: "Descreva a avaliação e apresente a justificativa para revisão.",
+    campos: [
+      { id: "disciplina", label: "Disciplina", tipo: "texto", obrigatorio: true },
+      { id: "professor", label: "Professor", tipo: "texto", obrigatorio: true },
+      { id: "turma", label: "Turma", tipo: "texto", obrigatorio: true },
+      {
+        id: "tipoAvaliacao",
+        label: "Tipo de avaliação",
+        tipo: "select",
+        obrigatorio: true,
+        opcoes: [
+          { label: "Prova", value: "prova" },
+          { label: "Trabalho", value: "trabalho" },
+          { label: "Atividade", value: "atividade" },
+          { label: "Projeto", value: "projeto" },
+          { label: "Outro", value: "outro" },
+        ],
+      },
+      { id: "notaLancada", label: "Nota lançada", tipo: "numero", obrigatorio: true, placeholder: "Ex.: 7.5" },
+      { id: "justificativa", label: "Justificativa", tipo: "textarea", obrigatorio: true },
+      {
+        id: "evidenciaAnexo",
+        label: "Evidência/anexo",
+        tipo: "arquivo",
+        obrigatorio: true,
+        accept: ".pdf,.jpg,.jpeg,.png,.doc,.docx",
+      },
+    ],
+  },
+  "secretaria-correcao-dados-siga": {
+    servicoId: "secretaria-correcao-dados-siga",
+    titulo: "Formulário de Correção de Dados no SIGA",
+    descricao: "Informe exatamente o dado incorreto e a correção solicitada.",
+    campos: [
+      {
+        id: "tipoDadoIncorreto",
+        label: "Tipo de dado incorreto",
+        tipo: "select",
+        obrigatorio: true,
+        opcoes: [
+          { label: "Nome", value: "nome" },
+          { label: "Documento", value: "documento" },
+          { label: "Endereço", value: "endereco" },
+          { label: "Telefone", value: "telefone" },
+          { label: "E-mail", value: "email" },
+          { label: "Outro", value: "outro" },
+        ],
+      },
+      { id: "ondeApareceErro", label: "Onde aparece o erro", tipo: "texto", obrigatorio: true },
+      { id: "informacaoAtual", label: "Informação atual", tipo: "textarea", obrigatorio: true },
+      { id: "informacaoCorreta", label: "Informação correta", tipo: "textarea", obrigatorio: true },
+      {
+        id: "documentoComprobatorio",
+        label: "Documento comprobatório",
+        tipo: "arquivo",
+        obrigatorio: true,
+        accept: ".pdf,.jpg,.jpeg,.png",
+      },
+    ],
+  },
+};
+
+export function getServiceFormConfig(servicoId: string): ServiceFormConfig | undefined {
+  return SERVICE_FORM_CONFIGS[servicoId];
+}
+
+export function validateServicePayload(servicoId: string, values: ServiceFormValues): ServicePayloadValidationResult {
+  const config = getServiceFormConfig(servicoId);
+  if (!config) return { valid: true, values };
+
+  const errors: Record<string, string> = {};
+
+  config.campos.forEach((campo) => {
+    const value = values[campo.id];
+    const isEmptyString = typeof value === "string" && value.trim().length === 0;
+    const isEmptyArray = Array.isArray(value) && value.length === 0;
+    const isMissing = value === undefined || value === null || isEmptyString || isEmptyArray;
+
+    if (campo.obrigatorio && isMissing) {
+      errors[campo.id] = requiredMessage(campo.label);
+      return;
+    }
+
+    if (campo.tipo === "numero" && typeof value === "string" && value.trim()) {
+      const normalized = value.replace(",", ".");
+      if (Number.isNaN(Number(normalized))) {
+        errors[campo.id] = `${campo.label} deve ser um número válido.`;
+      }
+    }
+  });
+
+  if (Object.keys(errors).length > 0) return { valid: false, errors };
+  return { valid: true, values };
+}
+
+export function getServicePayloadValidationMessages(servicoId: string, values: ServiceFormValues): string[] {
+  const result = validateServicePayload(servicoId, values);
+  if (result.valid) return [];
+  return Object.values(result.errors);
+}


### PR DESCRIPTION
### Motivation
- Provide per-service form configurations and client/server validation so academic requests require the correct fields and return clear errors when incomplete.
- Enable the student catalog to render and submit structured service forms (e.g., Declaração de Matrícula, Histórico, Aproveitamento, Revisão de Nota, Correção de Dados SIGA).

### Description
- Added a centralized form configuration and validation module at `utils/serviceForms.ts` defining form schemas, field types (including `checkbox` and `numero`) and `validateServicePayload` for required-field and number checks.
- Exposed form metadata in the institutional catalog by updating `utils/catalogo.ts` to include `formulario` information for services with configured forms via `getServiceFormConfig`.
- Implemented dynamic form rendering and a modal request flow in the student catalog at `app/(dashboard)/aluno/catalogo/page.tsx`, including typed form field components, client-side validation before send, packaging of `formulario` in the ticket payload and UI badges/disable logic for services without active forms.
- Added a Next.js API route proxy `app/tickets/route.ts` that validates incoming ticket payloads against `servicoId` using `validateServicePayload` and returns clear 400 errors for incomplete requests before forwarding valid requests to the backend tickets service.

### Testing
- Ran TypeScript type check with `pnpm exec tsc --noEmit` and it succeeded.
- Ran ESLint for modified files with `pnpm exec eslint 'app/(dashboard)/aluno/catalogo/page.tsx' app/tickets/route.ts utils/catalogo.ts utils/serviceForms.ts` and it passed for those files.
- Ran full lint `pnpm lint`, which failed due to pre-existing lint errors in unrelated files (many `@typescript-eslint/no-explicit-any` and similar issues) and not caused by these changes.
- Attempted production build with `pnpm build`, which failed in this environment because `next/font` could not fetch Google Fonts (network/font fetch issue), unrelated to form logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd36903d2c832e8649460e7250c632)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implementado modal de requisição de serviço com formulário dinâmico. Os usuários agora preenchem campos personalizados antes de criar um ticket. Suporte para múltiplos tipos de campo incluindo texto, número, data, arquivo, seleção e checkbox. Validação em tempo real de campos obrigatórios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->