### PR TITLE
fix: criação de chamado, notificações e tela de configurações do aluno

### DIFF
--- a/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
+++ b/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
@@ -5,79 +5,82 @@ import { Loader2, Info, Mail } from "lucide-react";
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
-/** Catálogo prático — Fatec Cotia */
 const COURSES = [
-  { key: "DSM",  sigla: "DSM",  nome: "Desenvolvimento de Software Multiplataforma" },
-  { key: "CD",   sigla: "CD",   nome: "Ciência de Dados" },
-  { key: "GPI",  sigla: "GPI",  nome: "Gestão da Produção Industrial" },
-  { key: "GE",   sigla: "GE",   nome: "Gestão Empresarial" },
-  { key: "DP",   sigla: "DP",   nome: "Design de Produto (ênfase em processos de produção)" },
-  { key: "COMEX",sigla: "COMEX",nome: "Comércio Exterior" },
+  { key: "DSM",   sigla: "DSM",   nome: "Desenvolvimento de Software Multiplataforma" },
+  { key: "CD",    sigla: "CD",    nome: "Ciência de Dados" },
+  { key: "GPI",   sigla: "GPI",   nome: "Gestão da Produção Industrial" },
+  { key: "GE",    sigla: "GE",    nome: "Gestão Empresarial" },
+  { key: "DP",    sigla: "DP",    nome: "Design de Produto (ênfase em processos de produção)" },
+  { key: "COMEX", sigla: "COMEX", nome: "Comércio Exterior" },
 ] as const;
+
+const TURNOS = ["Manhã", "Tarde", "Noite"] as const;
 
 type Props = {
   onSuccess?: (createdUser: any) => void;
   onCancel?: () => void;
 };
 
-export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
-  const [nome, setNome] = useState("");
-  const [emailEducacional, setEmailEducacional] = useState("");
-  const [ra, setRa] = useState("");
+const inputCls = "mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]";
+const labelCls = "block text-sm text-muted-foreground";
 
-  // seleção guiada de curso
-  const [courseKey, setCourseKey] = useState<string>(""); // "", "DSM", "CD", ... ou "OUTRO"
+export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
+  /* ── Identificação ── */
+  const [nome, setNome] = useState("");
+  const [ra, setRa] = useState("");
+  const [emailEducacional, setEmailEducacional] = useState("");
+  const [emailPessoal, setEmailPessoal] = useState("");
+
+  /* ── Curso ── */
+  const [courseKey, setCourseKey] = useState("");
   const [cursoNome, setCursoNome] = useState("");
   const [cursoSigla, setCursoSigla] = useState("");
 
+  /* ── Dados acadêmicos ── */
+  const [unidadeFatec, setUnidadeFatec] = useState("");
+  const [turno, setTurno] = useState("");
+  const [turma, setTurma] = useState("");
+  const [semestreAtual, setSemestreAtual] = useState("");
+  const [anoSemestreIngresso, setAnoSemestreIngresso] = useState("");
+
   const [submitting, setSubmitting] = useState(false);
 
-  // quando troca o select, preenche automatico; "OUTRO" libera campos manuais
   function handleCourseChange(val: string) {
     setCourseKey(val);
-    if (!val) {
-      setCursoNome("");
-      setCursoSigla("");
-      return;
-    }
-    if (val === "OUTRO") {
-      // libera os campos sem preencher
-      return;
-    }
-    const c = COURSES.find(c => c.key === val);
-    if (c) {
-      setCursoNome(c.nome);
-      setCursoSigla(c.sigla);
-    }
+    if (!val) { setCursoNome(""); setCursoSigla(""); return; }
+    if (val === "OUTRO") return;
+    const c = COURSES.find((c) => c.key === val);
+    if (c) { setCursoNome(c.nome); setCursoSigla(c.sigla); }
   }
 
   const canSubmit = useMemo(() => {
-    const idOk = ra.trim().length > 0;
+    const raOk = ra.trim().length > 0;
     const mailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailEducacional);
-    return idOk && mailOk && !submitting;
+    return raOk && mailOk && !submitting;
   }, [ra, emailEducacional, submitting]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!canSubmit) return;
-
     try {
       setSubmitting(true);
 
-      const payload: any = {
-        nome: nome || undefined,
+      const payload: Record<string, any> = {
+        nome: nome.trim() || undefined,
         emailEducacional,
-        emailPessoal: emailEducacional, // fallback
-        ra,
+        emailPessoal: emailPessoal.trim() || emailEducacional,
+        ra: ra.trim(),
         papel: "USUARIO",
         ativo: true,
-        // ❗ não envia senha: o backend define a senha temporária
-        // e marca precisaTrocarSenha = true para alunos (tem RA)
       };
 
-      // só envia curso se tiver algo preenchido (seletor ou manual)
-      if (cursoNome?.trim()) payload.cursoNome = cursoNome.trim();
-      if (cursoSigla?.trim()) payload.cursoSigla = cursoSigla.trim();
+      if (cursoNome.trim())           payload.cursoNome           = cursoNome.trim();
+      if (cursoSigla.trim())          payload.cursoSigla          = cursoSigla.trim();
+      if (unidadeFatec.trim())        payload.unidadeFatec        = unidadeFatec.trim();
+      if (turno)                      payload.turno               = turno;
+      if (turma.trim())               payload.turma               = turma.trim();
+      if (semestreAtual.trim())       payload.semestreAtual       = semestreAtual.trim();
+      if (anoSemestreIngresso.trim()) payload.anoSemestreIngresso = anoSemestreIngresso.trim();
 
       const res = await apiFetch(`${API_URL}/usuarios`, {
         method: "POST",
@@ -90,8 +93,7 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
         try {
           const json = JSON.parse(text);
           if (json?.issues?.length) {
-            const msg = json.issues.map((i: any) => `${i.path}: ${i.message}`).join(" | ");
-            throw new Error(`Validação falhou: ${msg}`);
+            throw new Error(json.issues.map((i: any) => `${i.path}: ${i.message}`).join(" | "));
           }
           throw new Error(json?.message || `Falha ao criar aluno (${res.status})`);
         } catch {
@@ -102,13 +104,10 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
       const created = await res.json();
       onSuccess?.(created);
 
-      // reset
-      setNome("");
-      setEmailEducacional("");
-      setRa("");
-      setCourseKey("");
-      setCursoNome("");
-      setCursoSigla("");
+      setNome(""); setRa(""); setEmailEducacional(""); setEmailPessoal("");
+      setCourseKey(""); setCursoNome(""); setCursoSigla("");
+      setUnidadeFatec(""); setTurno(""); setTurma("");
+      setSemestreAtual(""); setAnoSemestreIngresso("");
     } catch (err: any) {
       console.error(err);
       alert(err?.message ?? "Erro ao criar aluno");
@@ -118,141 +117,217 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {/* Linha 0 — aviso de fluxo */}
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Aviso de fluxo */}
       <div className="flex items-start gap-2 rounded-lg border border-dashed border-[var(--border)] bg-muted/40 p-3 text-xs text-muted-foreground">
-        <Info className="mt-0.5 size-4" />
+        <Info className="mt-0.5 size-4 shrink-0" />
         <p>
           Ao cadastrar o aluno, o sistema define uma <strong>senha temporária</strong> automaticamente
-          e, se configurado no backend, envia um <strong>link de primeiro acesso</strong> para o e-mail educacional.
+          e, se configurado, envia um <strong>link de primeiro acesso</strong> para o e-mail educacional.
         </p>
       </div>
 
-      {/* Linha 1 */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div>
-          <label className="text-sm text-muted-foreground">Nome (opcional)</label>
-          <input
-            className="mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3"
-            placeholder="Ex.: Fulano da Silva"
-            value={nome}
-            onChange={(e) => setNome(e.target.value)}
-          />
-        </div>
+      {/* ── Seção: Identificação ── */}
+      <fieldset className="space-y-3">
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Identificação
+        </legend>
 
-        <div>
-          <label className="text-sm text-muted-foreground">RA *</label>
-          <input
-            className="mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3"
-            placeholder="Ex.: 123456"
-            value={ra}
-            onChange={(e) => setRa(e.target.value)}
-            required
-          />
-        </div>
-      </div>
-
-      {/* Linha 2 */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div>
-          <label className="text-sm text-muted-foreground">E-mail educacional *</label>
-          <div className="relative">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Nome completo <span className="text-muted-foreground/60">(opcional)</span></label>
             <input
-              type="email"
-              className="mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3 pr-9"
-              placeholder="nome.sobrenome@fatec.sp.gov.br"
-              value={emailEducacional}
-              onChange={(e) => setEmailEducacional(e.target.value)}
+              className={inputCls}
+              placeholder="Ex.: Fulano da Silva"
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+              maxLength={160}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>RA *</label>
+            <input
+              className={inputCls}
+              placeholder="Ex.: 1234567890123"
+              value={ra}
+              onChange={(e) => setRa(e.target.value)}
               required
+              maxLength={32}
             />
-            <span className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground">
-              <Mail className="size-4" />
-            </span>
           </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            É para esse e-mail que será enviado o link de primeiro acesso / redefinição de senha.
-          </p>
         </div>
 
-        <div className="text-xs text-muted-foreground flex items-start gap-2 mt-6 sm:mt-7">
-          <Info className="size-3 mt-0.5" />
-          <p>
-            Você não precisa informar a senha ao aluno. Ele definirá uma <strong>senha nova</strong> no primeiro acesso,
-            usando o link enviado por e-mail.
-          </p>
-        </div>
-      </div>
-
-      {/* Linha 3 — Curso (UX prática) */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div>
-          <label className="text-sm text-muted-foreground">Curso</label>
-          <select
-            className="mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3"
-            value={courseKey}
-            onChange={(e) => handleCourseChange(e.target.value)}
-          >
-            <option value="">Selecione um curso…</option>
-            {COURSES.map(c => (
-              <option key={c.key} value={c.key}>{c.nome} — {c.sigla}</option>
-            ))}
-            <option value="OUTRO">Outro curso…</option>
-          </select>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Ao selecionar, os campos abaixo são preenchidos automaticamente.
-          </p>
-        </div>
-
-        {/* quando OUTRO, mostra os campos pra digitar; caso contrário, exibe preenchidos e editáveis */}
-        <div className="grid grid-cols-2 gap-2">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label className="text-sm text-muted-foreground">Sigla</label>
-            <input
-              className="mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3"
-              placeholder="Ex.: DSM"
-              value={cursoSigla}
-              onChange={(e) => setCursoSigla(e.target.value)}
-              disabled={!courseKey} // só habilita após selecionar algo (inclui OUTRO)
-            />
+            <label className={labelCls}>E-mail educacional *</label>
+            <div className="relative">
+              <input
+                type="email"
+                className={inputCls + " pr-9"}
+                placeholder="nome.sobrenome@fatec.sp.gov.br"
+                value={emailEducacional}
+                onChange={(e) => setEmailEducacional(e.target.value)}
+                required
+              />
+              <Mail className="absolute right-3 top-1/2 translate-y-px -translate-y-1/2 mt-0.5 size-4 text-muted-foreground pointer-events-none" />
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Link de primeiro acesso será enviado para este endereço.
+            </p>
           </div>
           <div>
-            <label className="text-sm text-muted-foreground">Nome do curso</label>
+            <label className={labelCls}>E-mail pessoal <span className="text-muted-foreground/60">(opcional)</span></label>
+            <div className="relative">
+              <input
+                type="email"
+                className={inputCls + " pr-9"}
+                placeholder="Ex.: nome@gmail.com"
+                value={emailPessoal}
+                onChange={(e) => setEmailPessoal(e.target.value)}
+              />
+              <Mail className="absolute right-3 top-1/2 translate-y-px -translate-y-1/2 mt-0.5 size-4 text-muted-foreground pointer-events-none" />
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      {/* ── Seção: Curso ── */}
+      <fieldset className="space-y-3">
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Curso <span className="normal-case text-muted-foreground/60 font-normal">(opcional)</span>
+        </legend>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Curso</label>
+            <select
+              className={inputCls}
+              value={courseKey}
+              onChange={(e) => handleCourseChange(e.target.value)}
+            >
+              <option value="">Selecione um curso…</option>
+              {COURSES.map((c) => (
+                <option key={c.key} value={c.key}>
+                  {c.nome} — {c.sigla}
+                </option>
+              ))}
+              <option value="OUTRO">Outro curso…</option>
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className={labelCls}>Sigla</label>
+              <input
+                className={inputCls}
+                placeholder="Ex.: DSM"
+                value={cursoSigla}
+                onChange={(e) => setCursoSigla(e.target.value)}
+                disabled={!courseKey}
+                maxLength={16}
+              />
+            </div>
+            <div>
+              <label className={labelCls}>Nome do curso</label>
+              <input
+                className={inputCls}
+                placeholder="Nome completo"
+                value={cursoNome}
+                onChange={(e) => setCursoNome(e.target.value)}
+                disabled={!courseKey}
+                maxLength={128}
+              />
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      {/* ── Seção: Dados Acadêmicos ── */}
+      <fieldset className="space-y-3">
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Dados Acadêmicos <span className="normal-case text-muted-foreground/60 font-normal">(opcionais)</span>
+        </legend>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Unidade Fatec</label>
             <input
-              className="mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3"
-              placeholder="Ex.: Desenvolvimento de Software Multiplataforma"
-              value={cursoNome}
-              onChange={(e) => setCursoNome(e.target.value)}
-              disabled={!courseKey}
+              className={inputCls}
+              placeholder="Ex.: Fatec Cotia"
+              value={unidadeFatec}
+              onChange={(e) => setUnidadeFatec(e.target.value)}
+              maxLength={128}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Turno</label>
+            <select
+              className={inputCls}
+              value={turno}
+              onChange={(e) => setTurno(e.target.value)}
+            >
+              <option value="">Selecione…</option>
+              {TURNOS.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div>
+            <label className={labelCls}>Turma</label>
+            <input
+              className={inputCls}
+              placeholder="Ex.: DSM-3A"
+              value={turma}
+              onChange={(e) => setTurma(e.target.value)}
+              maxLength={64}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Semestre atual</label>
+            <input
+              className={inputCls}
+              placeholder="Ex.: 3"
+              value={semestreAtual}
+              onChange={(e) => setSemestreAtual(e.target.value)}
+              maxLength={32}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Ano/semestre de ingresso</label>
+            <input
+              className={inputCls}
+              placeholder="Ex.: 2023/1"
+              value={anoSemestreIngresso}
+              onChange={(e) => setAnoSemestreIngresso(e.target.value)}
+              maxLength={32}
             />
           </div>
         </div>
-      </div>
+      </fieldset>
 
-      {/* Ações */}
-      <div className="flex items-center justify-end gap-2 pt-2">
+      {/* ── Ações ── */}
+      <div className="flex items-center justify-end gap-2 pt-2 border-t border-[var(--border)]">
         {onCancel && (
           <button
             type="button"
             onClick={onCancel}
-            className="h-10 px-3 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
+            className="h-10 px-4 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
           >
             Cancelar
           </button>
         )}
-
         <button
           type="submit"
           disabled={!canSubmit}
           className="inline-flex items-center gap-2 h-10 px-4 rounded-lg bg-primary text-primary-foreground text-sm hover:brightness-95 disabled:opacity-60"
         >
           {submitting ? (
-            <>
-              <Loader2 className="size-4 animate-spin" /> Salvando…
-            </>
+            <><Loader2 className="size-4 animate-spin" /> Salvando…</>
           ) : (
-            <>
-              Criar aluno
-            </>
+            "Criar aluno"
           )}
         </button>
       </div>

--- a/app/(dashboard)/admin/_components/FormAlunoEdit.tsx
+++ b/app/(dashboard)/admin/_components/FormAlunoEdit.tsx
@@ -1,0 +1,360 @@
+"use client";
+import { apiFetch } from "../../../../utils/api";
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, X } from "lucide-react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+const TURNOS = ["Manhã", "Tarde", "Noite"] as const;
+const CANAIS = ["E-mail", "WhatsApp", "Telefone", "Presencial"] as const;
+const PERIODOS = ["Manhã", "Tarde", "Noite", "Qualquer horário"] as const;
+
+type AlunoData = {
+  id: string;
+  nome?: string | null;
+  emailPessoal?: string | null;
+  emailEducacional?: string | null;
+  ra?: string | null;
+  ativo?: boolean;
+  cursoNome?: string | null;
+  cursoSigla?: string | null;
+  unidadeFatec?: string | null;
+  curso?: string | null;
+  eixoTecnologico?: string | null;
+  turno?: string | null;
+  turma?: string | null;
+  semestreAtual?: string | null;
+  matrizCurricular?: string | null;
+  situacaoAcademica?: string | null;
+  anoSemestreIngresso?: string | null;
+  coordenadorCurso?: string | null;
+  telefoneCelular?: string | null;
+  whatsapp?: string | null;
+  canalPreferencialContato?: string | null;
+  melhorPeriodoContato?: string | null;
+  necessitaAtendimentoAcessivel?: boolean | null;
+  tipoAcessibilidade?: string | null;
+  observacoesAtendimento?: string | null;
+};
+
+type Props = {
+  aluno: AlunoData;
+  onClose: () => void;
+  onSaved: (updated: AlunoData) => void;
+};
+
+const inputCls = "mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]";
+const labelCls = "block text-sm text-muted-foreground";
+const sectionCls = "text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3 pb-1 border-b border-[var(--border)]";
+
+export default function FormAlunoEdit({ aluno, onClose, onSaved }: Props) {
+  const [nome,                        setNome]                        = useState(aluno.nome ?? "");
+  const [emailPessoal,                setEmailPessoal]                = useState(aluno.emailPessoal ?? "");
+  const [emailEducacional,            setEmailEducacional]            = useState(aluno.emailEducacional ?? "");
+  const [ra,                          setRa]                          = useState(aluno.ra ?? "");
+  const [ativo,                       setAtivo]                       = useState(aluno.ativo ?? true);
+
+  const [cursoNome,                   setCursoNome]                   = useState(aluno.cursoNome ?? "");
+  const [cursoSigla,                  setCursoSigla]                  = useState(aluno.cursoSigla ?? "");
+  const [curso,                       setCurso]                       = useState(aluno.curso ?? "");
+  const [eixoTecnologico,             setEixoTecnologico]             = useState(aluno.eixoTecnologico ?? "");
+  const [matrizCurricular,            setMatrizCurricular]            = useState(aluno.matrizCurricular ?? "");
+
+  const [unidadeFatec,                setUnidadeFatec]                = useState(aluno.unidadeFatec ?? "");
+  const [turno,                       setTurno]                       = useState(aluno.turno ?? "");
+  const [turma,                       setTurma]                       = useState(aluno.turma ?? "");
+  const [semestreAtual,               setSemestreAtual]               = useState(aluno.semestreAtual ?? "");
+  const [anoSemestreIngresso,         setAnoSemestreIngresso]         = useState(aluno.anoSemestreIngresso ?? "");
+  const [situacaoAcademica,           setSituacaoAcademica]           = useState(aluno.situacaoAcademica ?? "");
+  const [coordenadorCurso,            setCoordenadorCurso]            = useState(aluno.coordenadorCurso ?? "");
+
+  const [telefoneCelular,             setTelefoneCelular]             = useState(aluno.telefoneCelular ?? "");
+  const [whatsapp,                    setWhatsapp]                    = useState(aluno.whatsapp ?? "");
+  const [canalPreferencialContato,    setCanalPreferencialContato]    = useState(aluno.canalPreferencialContato ?? "");
+  const [melhorPeriodoContato,        setMelhorPeriodoContato]        = useState(aluno.melhorPeriodoContato ?? "");
+
+  const [necessitaAtendimentoAcessivel, setNecessitaAtendimentoAcessivel] = useState(aluno.necessitaAtendimentoAcessivel ?? false);
+  const [tipoAcessibilidade,          setTipoAcessibilidade]          = useState(aluno.tipoAcessibilidade ?? "");
+  const [observacoesAtendimento,      setObservacoesAtendimento]      = useState(aluno.observacoesAtendimento ?? "");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fecha ao pressionar Esc
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      setSubmitting(true);
+      setError(null);
+
+      const payload: Record<string, any> = {
+        nome:             nome.trim()             || null,
+        emailPessoal:     emailPessoal.trim()     || null,
+        emailEducacional: emailEducacional.trim() || null,
+        ra:               ra.trim()               || null,
+        ativo,
+        cursoNome:           cursoNome.trim()           || null,
+        cursoSigla:          cursoSigla.trim()          || null,
+        curso:               curso.trim()               || null,
+        eixoTecnologico:     eixoTecnologico.trim()     || null,
+        matrizCurricular:    matrizCurricular.trim()    || null,
+        unidadeFatec:        unidadeFatec.trim()        || null,
+        turno:               turno                      || null,
+        turma:               turma.trim()               || null,
+        semestreAtual:       semestreAtual.trim()       || null,
+        anoSemestreIngresso: anoSemestreIngresso.trim() || null,
+        situacaoAcademica:   situacaoAcademica.trim()   || null,
+        coordenadorCurso:    coordenadorCurso.trim()    || null,
+        telefoneCelular:     telefoneCelular.trim()     || null,
+        whatsapp:            whatsapp.trim()            || null,
+        canalPreferencialContato: canalPreferencialContato || null,
+        melhorPeriodoContato:     melhorPeriodoContato     || null,
+        necessitaAtendimentoAcessivel,
+        tipoAcessibilidade:     tipoAcessibilidade.trim()     || null,
+        observacoesAtendimento: observacoesAtendimento.trim() || null,
+      };
+
+      const res = await apiFetch(`${API_URL}/usuarios/${aluno.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        try {
+          const json = JSON.parse(text);
+          throw new Error(json?.message || `Falha ao atualizar (${res.status})`);
+        } catch {
+          throw new Error(text || `Falha ao atualizar (${res.status})`);
+        }
+      }
+
+      const updated = await res.json();
+      onSaved(updated);
+    } catch (err: any) {
+      console.error(err);
+      setError(err?.message ?? "Erro ao salvar");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="relative z-10 mt-8 w-[95%] max-w-3xl max-h-[90vh] overflow-y-auto bg-background rounded-xl shadow-xl border border-[var(--border)]">
+        {/* Header */}
+        <div className="sticky top-0 z-10 bg-background flex items-center justify-between px-5 py-4 border-b border-[var(--border)]">
+          <h2 className="font-semibold text-base">Editar aluno</h2>
+          <button onClick={onClose} className="inline-grid place-items-center size-8 rounded-md hover:bg-[var(--muted)]">
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-5 space-y-7">
+          {error && (
+            <div className="rounded-lg bg-red-50 border border-red-200 text-red-800 px-4 py-3 text-sm">
+              {error}
+            </div>
+          )}
+
+          {/* ── Identificação ── */}
+          <section>
+            <p className={sectionCls}>Identificação</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="sm:col-span-2">
+                <label className={labelCls}>Nome completo</label>
+                <input className={inputCls} placeholder="Ex.: Fulano da Silva" value={nome} onChange={(e) => setNome(e.target.value)} maxLength={160} />
+              </div>
+              <div>
+                <label className={labelCls}>RA</label>
+                <input className={inputCls} placeholder="Ex.: 1234567890123" value={ra} onChange={(e) => setRa(e.target.value)} maxLength={32} />
+              </div>
+              <div className="flex items-center gap-3 pt-6">
+                <input
+                  type="checkbox"
+                  id="ativo"
+                  checked={ativo}
+                  onChange={(e) => setAtivo(e.target.checked)}
+                  className="h-4 w-4 rounded border-[var(--border)]"
+                />
+                <label htmlFor="ativo" className="text-sm cursor-pointer">Conta ativa</label>
+              </div>
+              <div>
+                <label className={labelCls}>E-mail educacional</label>
+                <input type="email" className={inputCls} placeholder="nome@fatec.sp.gov.br" value={emailEducacional} onChange={(e) => setEmailEducacional(e.target.value)} />
+              </div>
+              <div>
+                <label className={labelCls}>E-mail pessoal</label>
+                <input type="email" className={inputCls} placeholder="nome@gmail.com" value={emailPessoal} onChange={(e) => setEmailPessoal(e.target.value)} />
+              </div>
+            </div>
+          </section>
+
+          {/* ── Curso ── */}
+          <section>
+            <p className={sectionCls}>Curso</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className={labelCls}>Nome do curso</label>
+                <input className={inputCls} placeholder="Ex.: Desenvolvimento de Software Multiplataforma" value={cursoNome} onChange={(e) => setCursoNome(e.target.value)} maxLength={128} />
+              </div>
+              <div>
+                <label className={labelCls}>Sigla do curso</label>
+                <input className={inputCls} placeholder="Ex.: DSM" value={cursoSigla} onChange={(e) => setCursoSigla(e.target.value)} maxLength={16} />
+              </div>
+              <div>
+                <label className={labelCls}>Curso (campo livre)</label>
+                <input className={inputCls} placeholder="Denominação oficial" value={curso} onChange={(e) => setCurso(e.target.value)} maxLength={128} />
+              </div>
+              <div>
+                <label className={labelCls}>Eixo tecnológico</label>
+                <input className={inputCls} placeholder="Ex.: Informação e Comunicação" value={eixoTecnologico} onChange={(e) => setEixoTecnologico(e.target.value)} maxLength={128} />
+              </div>
+              <div className="sm:col-span-2">
+                <label className={labelCls}>Matriz curricular</label>
+                <input className={inputCls} placeholder="Ex.: 2023" value={matrizCurricular} onChange={(e) => setMatrizCurricular(e.target.value)} maxLength={128} />
+              </div>
+            </div>
+          </section>
+
+          {/* ── Dados Acadêmicos ── */}
+          <section>
+            <p className={sectionCls}>Dados Acadêmicos</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className={labelCls}>Unidade Fatec</label>
+                <input className={inputCls} placeholder="Ex.: Fatec Cotia" value={unidadeFatec} onChange={(e) => setUnidadeFatec(e.target.value)} maxLength={128} />
+              </div>
+              <div>
+                <label className={labelCls}>Turno</label>
+                <select className={inputCls} value={turno} onChange={(e) => setTurno(e.target.value)}>
+                  <option value="">Selecione…</option>
+                  {TURNOS.map((t) => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className={labelCls}>Turma</label>
+                <input className={inputCls} placeholder="Ex.: DSM-3A" value={turma} onChange={(e) => setTurma(e.target.value)} maxLength={64} />
+              </div>
+              <div>
+                <label className={labelCls}>Semestre atual</label>
+                <input className={inputCls} placeholder="Ex.: 3" value={semestreAtual} onChange={(e) => setSemestreAtual(e.target.value)} maxLength={32} />
+              </div>
+              <div>
+                <label className={labelCls}>Ano/semestre de ingresso</label>
+                <input className={inputCls} placeholder="Ex.: 2023/1" value={anoSemestreIngresso} onChange={(e) => setAnoSemestreIngresso(e.target.value)} maxLength={32} />
+              </div>
+              <div>
+                <label className={labelCls}>Situação acadêmica</label>
+                <input className={inputCls} placeholder="Ex.: Regular, Trancado…" value={situacaoAcademica} onChange={(e) => setSituacaoAcademica(e.target.value)} maxLength={128} />
+              </div>
+              <div className="sm:col-span-2">
+                <label className={labelCls}>Coordenador do curso</label>
+                <input className={inputCls} placeholder="Ex.: Prof. Fulano de Tal" value={coordenadorCurso} onChange={(e) => setCoordenadorCurso(e.target.value)} maxLength={128} />
+              </div>
+            </div>
+          </section>
+
+          {/* ── Contato ── */}
+          <section>
+            <p className={sectionCls}>Contato</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className={labelCls}>Telefone celular</label>
+                <input className={inputCls} placeholder="Ex.: (11) 99999-9999" value={telefoneCelular} onChange={(e) => setTelefoneCelular(e.target.value)} maxLength={20} />
+              </div>
+              <div>
+                <label className={labelCls}>WhatsApp</label>
+                <input className={inputCls} placeholder="Ex.: (11) 99999-9999" value={whatsapp} onChange={(e) => setWhatsapp(e.target.value)} maxLength={20} />
+              </div>
+              <div>
+                <label className={labelCls}>Canal preferencial de contato</label>
+                <select className={inputCls} value={canalPreferencialContato} onChange={(e) => setCanalPreferencialContato(e.target.value)}>
+                  <option value="">Selecione…</option>
+                  {CANAIS.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className={labelCls}>Melhor período para contato</label>
+                <select className={inputCls} value={melhorPeriodoContato} onChange={(e) => setMelhorPeriodoContato(e.target.value)}>
+                  <option value="">Selecione…</option>
+                  {PERIODOS.map((p) => <option key={p} value={p}>{p}</option>)}
+                </select>
+              </div>
+            </div>
+          </section>
+
+          {/* ── Acessibilidade ── */}
+          <section>
+            <p className={sectionCls}>Acessibilidade</p>
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  id="acessivel"
+                  checked={necessitaAtendimentoAcessivel}
+                  onChange={(e) => setNecessitaAtendimentoAcessivel(e.target.checked)}
+                  className="h-4 w-4 rounded border-[var(--border)]"
+                />
+                <label htmlFor="acessivel" className="text-sm cursor-pointer">
+                  Necessita de atendimento acessível
+                </label>
+              </div>
+
+              {necessitaAtendimentoAcessivel && (
+                <>
+                  <div>
+                    <label className={labelCls}>Tipo de acessibilidade</label>
+                    <input
+                      className={inputCls}
+                      placeholder="Ex.: Auditiva, Visual, Motora…"
+                      value={tipoAcessibilidade}
+                      onChange={(e) => setTipoAcessibilidade(e.target.value)}
+                      maxLength={256}
+                    />
+                  </div>
+                  <div>
+                    <label className={labelCls}>Observações de atendimento</label>
+                    <textarea
+                      className="mt-1 w-full rounded-lg border border-[var(--border)] bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)] min-h-[80px] resize-y"
+                      placeholder="Descreva as necessidades específicas…"
+                      value={observacoesAtendimento}
+                      onChange={(e) => setObservacoesAtendimento(e.target.value)}
+                      maxLength={2000}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
+          </section>
+
+          {/* ── Ações ── */}
+          <div className="sticky bottom-0 bg-background pt-4 pb-1 border-t border-[var(--border)] flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-10 px-4 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center gap-2 h-10 px-5 rounded-lg bg-primary text-primary-foreground text-sm hover:brightness-95 disabled:opacity-60"
+            >
+              {submitting ? <><Loader2 className="size-4 animate-spin" /> Salvando…</> : "Salvar alterações"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/_components/ImportAlunos.tsx
+++ b/app/(dashboard)/admin/_components/ImportAlunos.tsx
@@ -11,22 +11,45 @@ type ResultRow = {
   nome?: string;
   cursoNome?: string;
   cursoSigla?: string;
+  unidadeFatec?: string;
+  turno?: string;
+  turma?: string;
+  semestreAtual?: string;
+  anoSemestreIngresso?: string;
   status: "PENDING" | "OK" | "ERROR";
   errorMsg?: string;
-  note?: string; // ex.: "Já existia"
+  note?: string;
 };
 
 function cx(...xs: Array<string | false | null | undefined>) {
   return xs.filter(Boolean).join(" ");
 }
 
-/** Parser simples (CSV com vírgula, sem aspas complexas). */
-function parseCsvSimple(text: string): string[][] {
-  const lines = text
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter(Boolean);
-  return lines.map((l) => l.split(",").map((p) => p.trim()));
+/**
+ * CSV parser simples com suporte a campos entre aspas.
+ * Lida com vírgulas dentro de aspas duplas e aspas escapadas (""").
+ */
+function parseCsv(text: string): string[][] {
+  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  return lines.map((line) => {
+    const cols: string[] = [];
+    let cur = "";
+    let inQuote = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (inQuote) {
+        if (ch === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+        else if (ch === '"') { inQuote = false; }
+        else { cur += ch; }
+      } else {
+        if (ch === '"') { inQuote = true; }
+        else if (ch === ',') { cols.push(cur.trim()); cur = ""; }
+        else { cur += ch; }
+      }
+    }
+    cols.push(cur.trim());
+    return cols;
+  });
 }
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
@@ -45,10 +68,10 @@ export default function ImportAlunos({
   const fileRef = useRef<HTMLInputElement | null>(null);
 
   const total = rows.length;
-  const ok = rows.filter((r) => r.status === "OK").length;
-  const err = rows.filter((r) => r.status === "ERROR").length;
-  const done = ok + err;
-  const pct = total ? Math.round((done * 100) / total) : 0;
+  const ok    = rows.filter((r) => r.status === "OK").length;
+  const err   = rows.filter((r) => r.status === "ERROR").length;
+  const done  = ok + err;
+  const pct   = total ? Math.round((done * 100) / total) : 0;
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -56,7 +79,7 @@ export default function ImportAlunos({
     setFileName(file.name);
 
     const text = await file.text();
-    const raw = parseCsvSimple(text);
+    const raw  = parseCsv(text);
     if (raw.length <= 1) {
       alert("CSV vazio ou apenas header.");
       e.target.value = "";
@@ -64,46 +87,55 @@ export default function ImportAlunos({
     }
 
     const [header, ...data] = raw;
-    const mapIdx = (key: string) =>
-      header.findIndex((h) => h.toLowerCase() === key.toLowerCase());
+    const col = (key: string) =>
+      header.findIndex((h) => h.toLowerCase().trim() === key.toLowerCase());
 
-    const iRA = mapIdx("ra");
-    const iEdu = mapIdx("emailEducacional");
-    const iPes = mapIdx("emailPessoal");
-    const iNome = mapIdx("nome");
-    const iCursoNome = mapIdx("cursoNome");
-    const iCursoSigla = mapIdx("cursoSigla");
+    const iRA      = col("ra");
+    const iEdu     = col("emaileducacional");
+    const iPes     = col("emailpessoal");
+    const iNome    = col("nome");
+    const iCursoN  = col("cursonome");
+    const iCursoS  = col("cursosigla");
+    const iUnidade = col("unidadefatec");
+    const iTurno   = col("turno");
+    const iTurma   = col("turma");
+    const iSemest  = col("semestreatual");
+    const iIngress = col("anossemestreingresso") >= 0 ? col("anossemestreingresso") : col("anosemestreingresso");
 
     if (iRA < 0 || iEdu < 0) {
-      alert("Cabeçalho inválido. É obrigatório conter as colunas: ra, emailEducacional.");
+      alert("Cabeçalho inválido. Colunas obrigatórias: ra, emailEducacional.");
       e.target.value = "";
       return;
     }
 
     const seenRA = new Set<string>();
     const parsed: ResultRow[] = data.map((cols, idx) => {
-      const ra = (cols[iRA] || "").trim();
-      const emailEducacional = (cols[iEdu] || "").trim();
-      const emailPessoal = iPes >= 0 ? (cols[iPes] || "").trim() : "";
-      const nome = iNome >= 0 ? (cols[iNome] || "").trim() : "";
-      const cursoNome = iCursoNome >= 0 ? (cols[iCursoNome] || "").trim() : "";
-      const cursoSigla = iCursoSigla >= 0 ? (cols[iCursoSigla] || "").trim() : "";
+      const get = (i: number) => (i >= 0 ? (cols[i] ?? "").trim() : "");
+
+      const ra                = get(iRA);
+      const emailEducacional  = get(iEdu);
+      const emailPessoal      = get(iPes);
+      const nome              = get(iNome);
+      const cursoNome         = get(iCursoN);
+      const cursoSigla        = get(iCursoS);
+      const unidadeFatec      = get(iUnidade);
+      const turno             = get(iTurno);
+      const turma             = get(iTurma);
+      const semestreAtual     = get(iSemest);
+      const anoSemestreIngresso = get(iIngress);
 
       const row: ResultRow = {
         idx: idx + 1,
-        ra,
-        emailEducacional,
-        emailPessoal,
-        nome,
-        cursoNome,
-        cursoSigla,
+        ra, emailEducacional, emailPessoal,
+        nome, cursoNome, cursoSigla,
+        unidadeFatec, turno, turma, semestreAtual, anoSemestreIngresso,
         status: "PENDING",
       };
 
-      const key = ra.toLowerCase();
-      if (key) {
+      if (ra) {
+        const key = ra.toLowerCase();
         if (seenRA.has(key)) {
-          row.status = "ERROR";
+          row.status   = "ERROR";
           row.errorMsg = "RA duplicado no arquivo";
         } else {
           seenRA.add(key);
@@ -118,16 +150,12 @@ export default function ImportAlunos({
   }
 
   async function startImport() {
-    if (!rows.length) {
-      alert("Selecione um CSV primeiro.");
-      return;
-    }
+    if (!rows.length) { alert("Selecione um CSV primeiro."); return; }
     setRunning(true);
     setFinished(false);
 
     const token =
-      (typeof window !== "undefined" && localStorage.getItem("accessToken")) ||
-      "";
+      (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -145,15 +173,11 @@ export default function ImportAlunos({
         continue;
       }
 
-      const ra = r.ra?.trim();
+      const ra  = r.ra?.trim();
       const edu = r.emailEducacional?.trim();
 
       if (!ra || !edu) {
-        clone[i] = {
-          ...r,
-          status: "ERROR",
-          errorMsg: "RA e emailEducacional são obrigatórios.",
-        };
+        clone[i] = { ...r, status: "ERROR", errorMsg: "RA e emailEducacional são obrigatórios." };
         setRows([...clone]);
         continue;
       }
@@ -161,21 +185,22 @@ export default function ImportAlunos({
       const nomeFinal =
         (r.nome?.trim() || "").length >= 2 ? r.nome!.trim() : `Aluno ${ra}`;
 
-      const payload: any = {
-        emailPessoal: r.emailPessoal?.trim() || edu,
+      const payload: Record<string, any> = {
+        emailPessoal:    r.emailPessoal?.trim() || edu,
         emailEducacional: edu,
         ra,
         nome: nomeFinal,
-        cursoNome: r.cursoNome || undefined,
-        cursoSigla: r.cursoSigla || undefined,
         papel: "USUARIO",
         ativo: true,
-        // ❗ não envia senha nem precisaTrocarSenha
-        // Backend (createUser) detecta aluno via RA e:
-        // - define senha temporária padrão
-        // - marca precisaTrocarSenha = true
-        // - opcional: envia link de primeiro acesso / reset
       };
+
+      if (r.cursoNome?.trim())         payload.cursoNome           = r.cursoNome.trim();
+      if (r.cursoSigla?.trim())        payload.cursoSigla          = r.cursoSigla.trim();
+      if (r.unidadeFatec?.trim())      payload.unidadeFatec        = r.unidadeFatec.trim();
+      if (r.turno?.trim())             payload.turno               = r.turno.trim();
+      if (r.turma?.trim())             payload.turma               = r.turma.trim();
+      if (r.semestreAtual?.trim())     payload.semestreAtual       = r.semestreAtual.trim();
+      if (r.anoSemestreIngresso?.trim()) payload.anoSemestreIngresso = r.anoSemestreIngresso.trim();
 
       try {
         const resp = await fetch(`${API_URL}/usuarios`, {
@@ -193,24 +218,14 @@ export default function ImportAlunos({
             /unique/i.test(text) ||
             /P2002/.test(text);
 
-          if (isDuplicate) {
-            clone[i] = { ...r, status: "OK", note: "Já existia" };
-          } else {
-            clone[i] = {
-              ...r,
-              status: "ERROR",
-              errorMsg: text || `HTTP ${resp.status}`,
-            };
-          }
+          clone[i] = isDuplicate
+            ? { ...r, status: "OK", note: "Já existia" }
+            : { ...r, status: "ERROR", errorMsg: text || `HTTP ${resp.status}` };
         } else {
           clone[i] = { ...r, status: "OK" };
         }
       } catch (e: any) {
-        clone[i] = {
-          ...r,
-          status: "ERROR",
-          errorMsg: String(e?.message ?? e),
-        };
+        clone[i] = { ...r, status: "ERROR", errorMsg: String(e?.message ?? e) };
       }
 
       setRows([...clone]);
@@ -227,10 +242,7 @@ export default function ImportAlunos({
     if (fileRef.current) fileRef.current.value = "";
   }
 
-  const canStart = useMemo(
-    () => rows.length > 0 && !running,
-    [rows.length, running]
-  );
+  const canStart = useMemo(() => rows.length > 0 && !running, [rows.length, running]);
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-card p-4">
@@ -247,11 +259,10 @@ export default function ImportAlunos({
 
       {/* Aviso de fluxo */}
       <div className="mb-3 flex items-start gap-2 rounded-lg border border-dashed border-[var(--border)] bg-muted/40 p-3 text-xs text-muted-foreground">
-        <Info className="mt-0.5 size-4" />
+        <Info className="mt-0.5 size-4 shrink-0" />
         <p>
           Cada aluno importado será criado com uma <strong>senha temporária</strong> definida no backend
-          e marcado para <strong>trocar a senha no primeiro acesso</strong>. Se configurado, o sistema
-          pode enviar um e-mail automático com o link de primeiro acesso / redefinição.
+          e marcado para <strong>trocar a senha no primeiro acesso</strong>.
         </p>
       </div>
 
@@ -264,17 +275,9 @@ export default function ImportAlunos({
         >
           Selecionar arquivo
         </button>
-        <input
-          ref={fileRef}
-          type="file"
-          accept=".csv"
-          className="hidden"
-          onChange={handleFileChange}
-        />
+        <input ref={fileRef} type="file" accept=".csv" className="hidden" onChange={handleFileChange} />
         {fileName && (
-          <span className="text-sm text-muted-foreground truncate">
-            Arquivo: {fileName}
-          </span>
+          <span className="text-sm text-muted-foreground truncate">Arquivo: {fileName}</span>
         )}
       </div>
 
@@ -287,19 +290,16 @@ export default function ImportAlunos({
             <b className="text-[var(--brand-red)]">{err}</b>
           </div>
           <div className="h-2 w-full rounded-full bg-[var(--muted)] overflow-hidden">
-            <div
-              className="h-full bg-primary transition-[width]"
-              style={{ width: `${pct}%` }}
-            />
+            <div className="h-full bg-primary transition-[width]" style={{ width: `${pct}%` }} />
           </div>
         </div>
       )}
 
-      {/* Tabela */}
+      {/* Tabela de preview */}
       {!!rows.length && (
         <div className="mt-4 max-h-64 overflow-auto rounded-lg border border-[var(--border)]">
           <table className="min-w-full text-sm">
-            <thead className="bg-[var(--muted)]">
+            <thead className="bg-[var(--muted)] sticky top-0">
               <tr>
                 <th className="px-3 py-2 text-left">#</th>
                 <th className="px-3 py-2 text-left">RA</th>
@@ -307,6 +307,11 @@ export default function ImportAlunos({
                 <th className="px-3 py-2 text-left">E-mail pessoal</th>
                 <th className="px-3 py-2 text-left">Nome</th>
                 <th className="px-3 py-2 text-left">Curso</th>
+                <th className="px-3 py-2 text-left">Unidade</th>
+                <th className="px-3 py-2 text-left">Turno</th>
+                <th className="px-3 py-2 text-left">Turma</th>
+                <th className="px-3 py-2 text-left">Semestre</th>
+                <th className="px-3 py-2 text-left">Ingresso</th>
                 <th className="px-3 py-2 text-left">Status</th>
                 <th className="px-3 py-2 text-left">Erro</th>
               </tr>
@@ -319,27 +324,18 @@ export default function ImportAlunos({
                   <td className="px-3 py-2">{r.emailEducacional}</td>
                   <td className="px-3 py-2">{r.emailPessoal || "—"}</td>
                   <td className="px-3 py-2">{r.nome || `Aluno ${r.ra}`}</td>
+                  <td className="px-3 py-2">{r.cursoSigla || r.cursoNome || "—"}</td>
+                  <td className="px-3 py-2">{r.unidadeFatec || "—"}</td>
+                  <td className="px-3 py-2">{r.turno || "—"}</td>
+                  <td className="px-3 py-2">{r.turma || "—"}</td>
+                  <td className="px-3 py-2">{r.semestreAtual || "—"}</td>
+                  <td className="px-3 py-2">{r.anoSemestreIngresso || "—"}</td>
                   <td className="px-3 py-2">
-                    {r.cursoSigla || r.cursoNome || "—"}
+                    {r.status === "PENDING" && <span className="text-muted-foreground">Pendente</span>}
+                    {r.status === "OK"      && <span className="text-[var(--success)] font-medium">OK{r.note ? ` (${r.note})` : ""}</span>}
+                    {r.status === "ERROR"   && <span className="text-[var(--brand-red)] font-medium">Erro</span>}
                   </td>
-                  <td className="px-3 py-2">
-                    {r.status === "PENDING" && (
-                      <span className="text-muted-foreground">Pendente</span>
-                    )}
-                    {r.status === "OK" && (
-                      <span className="text-[var(--success)] font-medium">
-                        OK{r.note ? ` (${r.note})` : ""}
-                      </span>
-                    )}
-                    {r.status === "ERROR" && (
-                      <span className="text-[var(--brand-red)] font-medium">
-                        Erro
-                      </span>
-                    )}
-                  </td>
-                  <td className="px-3 py-2 text-xs text-[var(--brand-red)]">
-                    {r.errorMsg || "—"}
-                  </td>
+                  <td className="px-3 py-2 text-xs text-[var(--brand-red)]">{r.errorMsg || "—"}</td>
                 </tr>
               ))}
             </tbody>
@@ -356,7 +352,7 @@ export default function ImportAlunos({
             "h-9 px-3 rounded-md text-sm",
             canStart
               ? "bg-primary text-primary-foreground hover:brightness-95"
-              : "bg-[var(--muted)] text-muted-foreground cursor-not-allowed"
+              : "bg-[var(--muted)] text-muted-foreground cursor-not-allowed",
           )}
         >
           {running ? "Processando..." : rows.length ? "Processar importação" : "Selecionar CSV"}
@@ -367,7 +363,7 @@ export default function ImportAlunos({
           disabled={running || rows.length === 0}
           className={cx(
             "h-9 px-3 rounded-md border border-[var(--border)] text-sm",
-            running ? "opacity-60 cursor-not-allowed" : "hover:bg-[var(--muted)]"
+            running ? "opacity-60 cursor-not-allowed" : "hover:bg-[var(--muted)]",
           )}
         >
           Reiniciar
@@ -376,21 +372,27 @@ export default function ImportAlunos({
         <div className="ml-auto" />
 
         <button
-          onClick={() => {
-            if (finished) onDone();
-            else onClose();
-          }}
+          onClick={() => { if (finished) onDone(); else onClose(); }}
           className="h-9 px-3 rounded-md border border-[var(--border)] text-sm hover:bg-[var(--muted)]"
         >
           {finished ? "Concluir" : "Fechar"}
         </button>
       </div>
 
-      {/* Info */}
-      <div className="mt-3 text-xs text-muted-foreground">
-        Modelo CSV: <code>ra,emailEducacional,emailPessoal,nome,cursoNome,cursoSigla</code>.<br />
-        <b>Obrigatórios:</b> <code>ra</code>, <code>emailEducacional</code>.<br />
-        A senha temporária é definida automaticamente no backend e será exigida a troca no primeiro acesso.
+      {/* Info de formato */}
+      <div className="mt-3 text-xs text-muted-foreground space-y-1">
+        <p>
+          <b>Obrigatórios:</b> <code>ra</code>, <code>emailEducacional</code>
+        </p>
+        <p>
+          <b>Opcionais:</b>{" "}
+          <code>emailPessoal</code>, <code>nome</code>, <code>cursoNome</code>, <code>cursoSigla</code>,{" "}
+          <code>unidadeFatec</code>, <code>turno</code>, <code>turma</code>,{" "}
+          <code>semestreAtual</code>, <code>anoSemestreIngresso</code>, <code>ativo</code>
+        </p>
+        <p className="text-muted-foreground/70">
+          Use <strong>Modelo CSV</strong> para baixar o arquivo com todos os campos pré-formatados.
+        </p>
       </div>
     </div>
   );

--- a/app/(dashboard)/admin/_components/SidebarAdmin.tsx
+++ b/app/(dashboard)/admin/_components/SidebarAdmin.tsx
@@ -11,12 +11,13 @@ import {
   Settings,
   MessageSquareText,
   Building2,
-  Bell,
   LogOut,
-  //MessageCircleMore, // 💬 ícone de mensagens(Removido da sidebar)
 } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Cookies from 'js-cookie';
+import { apiFetch } from '../../../../utils/api';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 type NavItemProps = {
   href: string;
@@ -33,7 +34,7 @@ export default function SidebarAdmin({
   chamadosAbertosCount = 0,
   notificacoesCount = 0,
   pendenciasCount = 0,
-  mensagensCount = 0, // ✅ novo badge opcional
+  mensagensCount = 0,
   onClose,
 }: {
   chamadosAbertosCount?: number;
@@ -45,19 +46,36 @@ export default function SidebarAdmin({
   const pathname = usePathname();
   const router = useRouter();
 
+  const [slaMedioDias, setSlaMedioDias] = useState<number | null>(null);
+  const [pctResolvidos, setPctResolvidos] = useState<number | null>(null);
+  const [chamadosAbertosReal, setChamadosAbertosReal] = useState<number | null>(null);
+
+  useEffect(() => {
+    apiFetch(`${API_BASE}/tickets/stats`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data) return;
+        setSlaMedioDias(data.slaMedioDias ?? null);
+        setPctResolvidos(data.pctResolvidos ?? null);
+        setChamadosAbertosReal(data.porStatus?.ABERTO ?? null);
+      })
+      .catch(() => {});
+  }, []);
+
+  const chamadosBadge = chamadosAbertosReal ?? chamadosAbertosCount;
+
   const items: NavItemProps[] = useMemo(
     () => [
       { href: "/admin/home", label: "Visão Geral", icon: <LayoutDashboard className="size-4" /> },
-      { href: "/admin/chamados", label: "Todos os Chamados", icon: <Ticket className="size-4" />, badge: chamadosAbertosCount },
+      { href: "/admin/chamados", label: "Todos os Chamados", icon: <Ticket className="size-4" />, badge: chamadosBadge || undefined },
       { href: "/admin/alunos", label: "Gerenciar Alunos", icon: <Users className="size-4" />, badge: pendenciasCount || undefined },
       { href: "/admin/funcionarios", label: "Gerenciar Funcionários", icon: <UserPlus className="size-4" /> },
-      //{ href: "/admin/mensagens", label: "Mensagens", icon: <MessageCircleMore className="size-4" />, badge: mensagensCount || undefined }, // 💬 nova rota
-      { href: "/admin/comunicacoes", label: "Comunicações", icon: <MessageSquareText className="size-4" />, badge: notificacoesCount },
+      { href: "/admin/comunicacoes", label: "Comunicações", icon: <MessageSquareText className="size-4" />, badge: notificacoesCount || undefined },
       { href: "/admin/relatorios", label: "Relatórios", icon: <FileChartColumn className="size-4" /> },
       { href: "/admin/setores", label: "Setores", icon: <Building2 className="size-4" /> },
       { href: "/admin/configuracoes", label: "Configurações", icon: <Settings className="size-4" /> },
     ],
-    [chamadosAbertosCount, notificacoesCount, pendenciasCount]
+    [chamadosBadge, notificacoesCount, pendenciasCount]
   );
 
   function isActive(href: string) {
@@ -67,18 +85,14 @@ export default function SidebarAdmin({
 
   function handleLogout() {
     try {
-      // Limpa os cookies que o middleware lê
       Cookies.remove("accessToken");
       Cookies.remove("refreshToken");
-
-      // Limpa o localStorage
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
       localStorage.removeItem("userId");
     } catch (e) {
       console.error("Erro ao fazer logout:", e);
     }
-    // Redireciona para o login DEPOIS de limpar
     router.push("/login");
     onClose?.();
   }
@@ -136,11 +150,15 @@ export default function SidebarAdmin({
           <ul className="space-y-2 text-sm">
             <li className="flex items-center justify-between">
               <span>SLA médio (dias)</span>
-              <span className="font-medium">1,7</span>
+              <span className="font-medium">
+                {slaMedioDias != null ? slaMedioDias.toFixed(1) : "—"}
+              </span>
             </li>
             <li className="flex items-center justify-between">
               <span>% resolvidos</span>
-              <span className="font-medium">82%</span>
+              <span className="font-medium">
+                {pctResolvidos != null ? `${pctResolvidos}%` : "—"}
+              </span>
             </li>
             <li className="flex items-center justify-between">
               <span>Pendências</span>
@@ -148,8 +166,8 @@ export default function SidebarAdmin({
             </li>
           </ul>
         </div>
-      
-        {/* Sair (fixo no rodapé do sidebar) */}
+
+        {/* Sair */}
         <div className="mt-auto pt-3">
           <button
             type="button"

--- a/app/(dashboard)/admin/alunos/[id]/page.tsx
+++ b/app/(dashboard)/admin/alunos/[id]/page.tsx
@@ -6,14 +6,16 @@ import Link from "next/link";
 import {
   ArrowLeft, Mail, User, Badge, Shield, CheckCircle2, XCircle,
   Pencil, Trash2, KeyRound, AlertTriangle, Search, Filter,
-  ChevronRight, Loader2, Check, X, Ticket, Clock
+  ChevronRight, Loader2, Check, X, Ticket, Clock,
+  Phone, MessageCircle, GraduationCap, Building2, BookOpen,
 } from "lucide-react";
 
 import { cx } from '../../../../../utils/cx'
 import TicketStatusBadge from "../../../../components/shared/TicketStatusBadge";
 import KpiCard from "../../../../components/shared/KpiCard";
+import FormAlunoEdit from "../../_components/FormAlunoEdit";
 
-/* ===================== Tipos (alinhados ao Prisma) ===================== */
+/* ===================== Tipos ===================== */
 type Papel = "USUARIO" | "BACKOFFICE" | "TECNICO" | "ADMINISTRADOR";
 type StatusChamado = "ABERTO" | "EM_ATENDIMENTO" | "AGUARDANDO_USUARIO" | "RESOLVIDO" | "ENCERRADO";
 type Prioridade = "BAIXA" | "MEDIA" | "ALTA" | "URGENTE";
@@ -27,36 +29,87 @@ type Usuario = {
   ra: string | null;
   papel: Papel;
   ativo: boolean;
-  criadoEm: string;      // ISO
-  atualizadoEm: string;  // ISO
+  criadoEm: string;
+  atualizadoEm: string;
+  // Curso
+  cursoNome: string | null;
+  cursoSigla: string | null;
+  curso: string | null;
+  eixoTecnologico: string | null;
+  matrizCurricular: string | null;
+  // Dados acadêmicos
+  unidadeFatec: string | null;
+  turno: string | null;
+  turma: string | null;
+  semestreAtual: string | null;
+  anoSemestreIngresso: string | null;
+  situacaoAcademica: string | null;
+  coordenadorCurso: string | null;
+  // Contato
+  telefoneCelular: string | null;
+  whatsapp: string | null;
+  canalPreferencialContato: string | null;
+  melhorPeriodoContato: string | null;
+  // Acessibilidade
+  necessitaAtendimentoAcessivel: boolean | null;
+  tipoAcessibilidade: string | null;
+  observacoesAtendimento: string | null;
 };
 
 type Chamado = {
   id: string;
   protocolo?: string | null;
   titulo: string;
-  criadoEm: string; // ISO
+  criadoEm: string;
   status: StatusChamado;
   prioridade: Prioridade;
   nivel: Nivel;
-  setor?: string | null; // mapeado no backend (setor.nome)
+  setor?: string | null;
 };
 
-/* ===================== ENV ===================== */
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
-
 function Pill({ children }: { children: React.ReactNode }) {
-  return <span className="inline-flex items-center gap-1 rounded-md border border-[var(--border)] bg-background px-2 py-0.5 text-xs">{children}</span>;
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border border-[var(--border)] bg-background px-2 py-0.5 text-xs">
+      {children}
+    </span>
+  );
 }
 
 function Dot({ tone = "ok" as "ok" | "muted" }) {
-  return <span className={cx("inline-block size-2 rounded-full", tone === "ok" ? "bg-[var(--success)]" : "bg-[var(--muted-foreground)]")} />;
+  return (
+    <span
+      className={cx(
+        "inline-block size-2 rounded-full",
+        tone === "ok" ? "bg-[var(--success)]" : "bg-[var(--muted-foreground)]",
+      )}
+    />
+  );
 }
 
-function toast(msg: string) {
-  alert(msg);
+function InfoRow({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-sm mt-0.5">{value || <span className="text-muted-foreground/60">—</span>}</span>
+    </div>
+  );
 }
+
+function SectionCard({ title, icon, children }: { title: string; icon?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-card p-4">
+      <div className="flex items-center gap-2 mb-4">
+        {icon && <span className="text-muted-foreground">{icon}</span>}
+        <h3 className="font-medium text-sm">{title}</h3>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function toast(msg: string) { alert(msg); }
 
 /* ===================== Página ===================== */
 export default function PageAlunoDetalhe() {
@@ -75,6 +128,7 @@ export default function PageAlunoDetalhe() {
 
   const [delOpen, setDelOpen] = useState(false);
   const [delConfirmText, setDelConfirmText] = useState("");
+  const [editOpen, setEditOpen] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -82,10 +136,8 @@ export default function PageAlunoDetalhe() {
       try {
         setLoading(true);
         const token =
-          (typeof window !== "undefined" && localStorage.getItem("accessToken")) ||
-          "";
+          (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
 
-        // GET usuário
         const uRes = await fetch(`${API_URL}/usuarios/${id}`, {
           headers: { Authorization: token ? `Bearer ${token}` : "" },
           cache: "no-store",
@@ -93,32 +145,18 @@ export default function PageAlunoDetalhe() {
         if (!uRes.ok) throw new Error("Falha ao buscar usuário");
         const u: Usuario = await uRes.json();
 
-        // GET tickets do usuário (criadoPorId)
         const cRes = await fetch(`${API_URL}/tickets?criadoPorId=${u.id}`, {
           headers: { Authorization: token ? `Bearer ${token}` : "" },
           cache: "no-store",
         });
         if (!cRes.ok) throw new Error("Falha ao buscar tickets");
-        let json = await cRes.json();
-            let cs: Chamado[] = [];
+        const json = await cRes.json();
+        let cs: Chamado[] = [];
+        if (Array.isArray(json)) cs = json;
+        else if (Array.isArray(json.data)) cs = json.data;
+        else if (Array.isArray(json.tickets)) cs = json.tickets;
 
-            // Detecta formato retornado automaticamente
-            if (Array.isArray(json)) {
-            cs = json;
-            } else if (Array.isArray(json.data)) {
-            cs = json.data;
-            } else if (Array.isArray(json.tickets)) {
-            cs = json.tickets;
-            } else {
-            console.warn("Formato inesperado de /tickets:", json);
-            cs = [];
-            }
-
-
-        if (active) {
-          setAluno(u);
-          setChamados(cs);
-        }
+        if (active) { setAluno(u); setChamados(cs); }
       } catch (e) {
         console.error(e);
         if (active) toast("Erro ao carregar dados do usuário.");
@@ -127,17 +165,12 @@ export default function PageAlunoDetalhe() {
       }
     }
     if (id) load();
-    return () => {
-      active = false;
-    };
+    return () => { active = false; };
   }, [id]);
 
   const filtrados = useMemo(() => {
     return chamados.filter((c) => {
-      const mQ =
-        !q ||
-        c.titulo.toLowerCase().includes(q.toLowerCase()) ||
-        c.protocolo?.toLowerCase().includes(q.toLowerCase());
+      const mQ = !q || c.titulo.toLowerCase().includes(q.toLowerCase()) || c.protocolo?.toLowerCase().includes(q.toLowerCase());
       const mS = status === "ALL" || c.status === status;
       const mP = prioridade === "ALL" || c.prioridade === prioridade;
       const mN = nivel === "ALL" || c.nivel === nivel;
@@ -145,34 +178,27 @@ export default function PageAlunoDetalhe() {
     });
   }, [chamados, q, status, prioridade, nivel]);
 
-    async function onExcluirUsuario() {
-      if (!aluno) return;
-
-      if (delConfirmText !== (aluno.emailEducacional ?? aluno.emailPessoal)) {
-        toast("Digite exatamente o e-mail do usuário para confirmar.");
-        return;
-      }
-
-      try {
-        const res = await apiFetch(`${API_URL}/usuarios/${aluno.id}`, {
-          method: "DELETE",
-        });
-
-        if (!res.ok) throw new Error("Erro ao excluir");
-
-        toast("Usuário excluído com sucesso.");
-        router.push("/admin/alunos");
-      } catch (e) {
-        console.error(e);
-        toast("Não foi possível excluir o usuário.");
-      } finally {
-        setDelOpen(false);
-        setDelConfirmText("");
-      }
+  async function onExcluirUsuario() {
+    if (!aluno) return;
+    if (delConfirmText !== (aluno.emailEducacional ?? aluno.emailPessoal)) {
+      toast("Digite exatamente o e-mail do usuário para confirmar.");
+      return;
     }
+    try {
+      const res = await apiFetch(`${API_URL}/usuarios/${aluno.id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Erro ao excluir");
+      toast("Usuário excluído com sucesso.");
+      router.push("/admin/alunos");
+    } catch (e) {
+      console.error(e);
+      toast("Não foi possível excluir o usuário.");
+    } finally {
+      setDelOpen(false);
+      setDelConfirmText("");
+    }
+  }
 
   function onResetSenha() {
-    // aqui você pode chamar seu endpoint de reset e disparar email via Resend
     toast("Reset de senha enviado (stub).");
   }
 
@@ -192,10 +218,7 @@ export default function PageAlunoDetalhe() {
         <div className="rounded-xl border border-[var(--border)] bg-card p-6 text-center">
           <div className="text-lg font-semibold mb-1">Usuário não encontrado</div>
           <div className="text-sm text-muted-foreground">Verifique o ID na URL.</div>
-          <Link
-            href="/admin/alunos"
-            className="inline-flex items-center gap-2 mt-4 h-9 px-3 rounded-md border hover:bg-[var(--muted)] text-sm"
-          >
+          <Link href="/admin/alunos" className="inline-flex items-center gap-2 mt-4 h-9 px-3 rounded-md border hover:bg-[var(--muted)] text-sm">
             <ArrowLeft className="size-4" /> Voltar
           </Link>
         </div>
@@ -204,11 +227,11 @@ export default function PageAlunoDetalhe() {
   }
 
   const counts = {
-    abertos: chamados.filter((c) => c.status === "ABERTO").length,
-    andamento: chamados.filter((c) => c.status === "EM_ATENDIMENTO").length,
-    aguard: chamados.filter((c) => c.status === "AGUARDANDO_USUARIO").length,
+    abertos:    chamados.filter((c) => c.status === "ABERTO").length,
+    andamento:  chamados.filter((c) => c.status === "EM_ATENDIMENTO").length,
+    aguard:     chamados.filter((c) => c.status === "AGUARDANDO_USUARIO").length,
     resolvidos: chamados.filter((c) => c.status === "RESOLVIDO" || c.status === "ENCERRADO").length,
-    total: chamados.length,
+    total:      chamados.length,
   };
 
   return (
@@ -216,20 +239,16 @@ export default function PageAlunoDetalhe() {
       {/* Breadcrumb + voltar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Link
-            href="/admin/alunos"
-            className="inline-flex items-center gap-2 h-9 px-3 rounded-md border hover:bg-[var(--muted)] text-sm"
-          >
+          <Link href="/admin/alunos" className="inline-flex items-center gap-2 h-9 px-3 rounded-md border hover:bg-[var(--muted)] text-sm">
             <ArrowLeft className="size-4" /> Alunos
           </Link>
           <span className="text-muted-foreground">/</span>
           <span className="font-medium truncate max-w-[60vw]">{aluno.nome ?? "—"}</span>
         </div>
-
         <div className="flex items-center gap-2">
           <button
             className="inline-flex items-center gap-2 h-9 px-3 rounded-md border hover:bg-[var(--muted)] text-sm"
-            onClick={() => toast("Abrir editor (stub).")}
+            onClick={() => setEditOpen(true)}
           >
             <Pencil className="size-4" /> Editar
           </button>
@@ -258,26 +277,13 @@ export default function PageAlunoDetalhe() {
             <div>
               <div className="text-lg font-semibold">{aluno.nome ?? "—"}</div>
               <div className="flex flex-wrap gap-2 mt-1 text-sm">
-                <Pill>
-                  <Mail className="size-3" /> {aluno.emailEducacional ?? aluno.emailPessoal}
-                </Pill>
-                <Pill>
-                  <Badge className="size-3" /> RA: {aluno.ra ?? "—"}
-                </Pill>
-                <Pill>
-                  <Shield className="size-3" /> {aluno.papel}
-                </Pill>
-                <Pill>
-                  {aluno.ativo ? (
-                    <>
-                      <Dot /> Ativo
-                    </>
-                  ) : (
-                    <>
-                      <Dot tone="muted" /> Inativo
-                    </>
-                  )}
-                </Pill>
+                <Pill><Mail className="size-3" /> {aluno.emailEducacional ?? aluno.emailPessoal}</Pill>
+                {aluno.emailPessoal && aluno.emailEducacional && (
+                  <Pill><Mail className="size-3" /> {aluno.emailPessoal}</Pill>
+                )}
+                <Pill><Badge className="size-3" /> RA: {aluno.ra ?? "—"}</Pill>
+                <Pill><Shield className="size-3" /> {aluno.papel}</Pill>
+                <Pill>{aluno.ativo ? <><Dot /> Ativo</> : <><Dot tone="muted" /> Inativo</>}</Pill>
               </div>
             </div>
           </div>
@@ -286,6 +292,60 @@ export default function PageAlunoDetalhe() {
             {new Date(aluno.atualizadoEm).toLocaleDateString("pt-BR")}
           </div>
         </div>
+      </div>
+
+      {/* Cards de informações adicionais */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Dados Acadêmicos */}
+        <SectionCard title="Dados Acadêmicos" icon={<GraduationCap className="size-4" />}>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+            <InfoRow label="Unidade Fatec" value={aluno.unidadeFatec} />
+            <InfoRow label="Turno" value={aluno.turno} />
+            <InfoRow label="Curso" value={aluno.cursoNome ?? aluno.curso} />
+            <InfoRow label="Sigla" value={aluno.cursoSigla} />
+            <InfoRow label="Eixo tecnológico" value={aluno.eixoTecnologico} />
+            <InfoRow label="Turma" value={aluno.turma} />
+            <InfoRow label="Semestre atual" value={aluno.semestreAtual} />
+            <InfoRow label="Ingresso" value={aluno.anoSemestreIngresso} />
+            <InfoRow label="Situação acadêmica" value={aluno.situacaoAcademica} />
+            <InfoRow label="Matriz curricular" value={aluno.matrizCurricular} />
+            <div className="col-span-2">
+              <InfoRow label="Coordenador do curso" value={aluno.coordenadorCurso} />
+            </div>
+          </div>
+        </SectionCard>
+
+        {/* Contato & Acessibilidade */}
+        <SectionCard title="Contato & Acessibilidade" icon={<Phone className="size-4" />}>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+            <InfoRow label="Telefone celular" value={aluno.telefoneCelular} />
+            <InfoRow label="WhatsApp" value={aluno.whatsapp} />
+            <InfoRow label="Canal preferencial" value={aluno.canalPreferencialContato} />
+            <InfoRow label="Melhor período" value={aluno.melhorPeriodoContato} />
+            <div className="col-span-2">
+              <InfoRow
+                label="Atendimento acessível"
+                value={
+                  aluno.necessitaAtendimentoAcessivel === null
+                    ? undefined
+                    : aluno.necessitaAtendimentoAcessivel
+                    ? "Sim"
+                    : "Não"
+                }
+              />
+            </div>
+            {aluno.necessitaAtendimentoAcessivel && (
+              <>
+                <div className="col-span-2">
+                  <InfoRow label="Tipo de acessibilidade" value={aluno.tipoAcessibilidade} />
+                </div>
+                <div className="col-span-2">
+                  <InfoRow label="Observações" value={aluno.observacoesAtendimento} />
+                </div>
+              </>
+            )}
+          </div>
+        </SectionCard>
       </div>
 
       {/* KPIs */}
@@ -309,7 +369,6 @@ export default function PageAlunoDetalhe() {
               onChange={(e) => setQ(e.target.value)}
             />
           </div>
-
           <div className="flex gap-2 w-full sm:w-auto">
             <div className="relative">
               <Filter className="size-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
@@ -326,7 +385,6 @@ export default function PageAlunoDetalhe() {
                 <option value="ENCERRADO">Encerrado</option>
               </select>
             </div>
-
             <select
               className="h-10 w-[160px] rounded-lg border border-[var(--border)] bg-background px-3"
               value={prioridade}
@@ -338,7 +396,6 @@ export default function PageAlunoDetalhe() {
               <option value="ALTA">Alta</option>
               <option value="URGENTE">Urgente</option>
             </select>
-
             <select
               className="h-10 w-[130px] rounded-lg border border-[var(--border)] bg-background px-3"
               value={nivel}
@@ -370,27 +427,16 @@ export default function PageAlunoDetalhe() {
               {filtrados.map((c) => (
                 <tr key={c.id} className="border-t border-[var(--border)]">
                   <td className="px-4 py-3 font-medium">{c.protocolo ?? `#${c.id}`}</td>
-                  <td className="px-4 py-3 max-w-[360px]">
-                    <div className="line-clamp-1">{c.titulo}</div>
-                  </td>
+                  <td className="px-4 py-3 max-w-[360px]"><div className="line-clamp-1">{c.titulo}</div></td>
                   <td className="px-4 py-3 hidden md:table-cell">{c.setor ?? "—"}</td>
                   <td className="px-4 py-3 hidden lg:table-cell">{c.nivel}</td>
-                  <td className="px-4 py-3">
-                    <TicketStatusBadge status={c.status} />
-                  </td>
+                  <td className="px-4 py-3"><TicketStatusBadge status={c.status} /></td>
                   <td className="px-4 py-3 hidden lg:table-cell">{c.prioridade}</td>
                   <td className="px-4 py-3 hidden lg:table-cell">
-                    {new Date(c.criadoEm).toLocaleDateString("pt-BR", {
-                      day: "2-digit",
-                      month: "2-digit",
-                      year: "numeric",
-                    })}
+                    {new Date(c.criadoEm).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit", year: "numeric" })}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <Link
-                      href={`/admin/chamados/${c.id}`}
-                      className="inline-flex items-center h-9 px-3 rounded-md hover:bg-[var(--muted)]"
-                    >
+                    <Link href={`/admin/chamados/${c.id}`} className="inline-flex items-center h-9 px-3 rounded-md hover:bg-[var(--muted)]">
                       Detalhes <ChevronRight className="size-4 ml-1" />
                     </Link>
                   </td>
@@ -407,6 +453,18 @@ export default function PageAlunoDetalhe() {
           </table>
         </div>
       </div>
+
+      {/* Modal de edição */}
+      {editOpen && aluno && (
+        <FormAlunoEdit
+          aluno={aluno}
+          onClose={() => setEditOpen(false)}
+          onSaved={(updated) => {
+            setAluno((prev) => prev ? { ...prev, ...updated } : prev);
+            setEditOpen(false);
+          }}
+        />
+      )}
 
       {/* Dialog de exclusão */}
       {delOpen && (
@@ -444,7 +502,7 @@ export default function PageAlunoDetalhe() {
                   "inline-flex items-center gap-2 h-9 px-3 rounded-md text-sm",
                   delConfirmText === (aluno.emailEducacional ?? aluno.emailPessoal)
                     ? "bg-red-600 text-white hover:brightness-95"
-                    : "bg-red-600/50 text-white/80 cursor-not-allowed"
+                    : "bg-red-600/50 text-white/80 cursor-not-allowed",
                 )}
                 onClick={onExcluirUsuario}
                 disabled={delConfirmText !== (aluno.emailEducacional ?? aluno.emailPessoal)}
@@ -458,4 +516,3 @@ export default function PageAlunoDetalhe() {
     </div>
   );
 }
-

--- a/app/(dashboard)/admin/alunos/page.tsx
+++ b/app/(dashboard)/admin/alunos/page.tsx
@@ -11,7 +11,7 @@ import {
   Mail,
   IdCard,
   User as UserIcon,
-  Trash2, // 👈 novo
+  Trash2,
 } from "lucide-react";
 
 import FormAlunoCreate from "./../_components/FormAlunoCreate";
@@ -30,8 +30,8 @@ type Usuario = {
   emailEducacional: string | null;
   ra: string | null;
   ativo: boolean;
-  criadoEm: string; // ISO
-  papel?: Papel | null; // pode vir ausente do backend
+  criadoEm: string;
+  papel?: Papel | null;
 };
 
 type AlunoRow = {
@@ -45,23 +45,14 @@ type AlunoRow = {
 
 /* ========= ENV ========= */
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
-
 const USERS_PATH = process.env.NEXT_PUBLIC_USERS_PATH ?? "/auth/usuarios";
-
-// detalhe do aluno
 const ALUNO_DETAIL_PREFIX = "/admin/alunos/";
-
-/* ========= Utils ========= 
-function cx(...xs: Array<string | false | null | undefined>) {
-  return xs.filter(Boolean).join(" ");
-}*/
 
 function StatusBadge({ status }: { status: StatusAtivo }) {
   const map: Record<StatusAtivo, string> = {
     ATIVO: "bg-[var(--success)]/12 text-[var(--success)] border-[var(--success)]/30",
     INATIVO: "bg-[var(--muted)] text-muted-foreground border-[var(--border)]",
   };
-  const label = status === "ATIVO" ? "Ativo" : "Inativo";
   return (
     <span
       className={cx(
@@ -69,7 +60,7 @@ function StatusBadge({ status }: { status: StatusAtivo }) {
         map[status],
       )}
     >
-      {label}
+      {status === "ATIVO" ? "Ativo" : "Inativo"}
     </span>
   );
 }
@@ -86,11 +77,9 @@ export default function AdminAlunosPage() {
   const [total, setTotal] = useState<number>(0);
   const [error, setError] = useState<null | string>(null);
 
-  // seleção em massa
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [deleting, setDeleting] = useState(false);
 
-  // paginação simples
   const [page, setPage] = useState(1);
   const perPage = 20;
 
@@ -100,31 +89,22 @@ export default function AdminAlunosPage() {
       setError(null);
 
       const token =
-        (typeof window !== "undefined" && localStorage.getItem("accessToken")) ||
-        "";
+        (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
 
       const headers: Record<string, string> = { Accept: "application/json" };
       if (token) headers.Authorization = `Bearer ${token}`;
 
       const qs = new URLSearchParams();
-      // ainda enviamos a intenção para o backend (caso ele já suporte)
       qs.set("papel", "USUARIO");
       if (q) qs.set("search", q);
       if (status !== "ALL") qs.set("ativo", String(status === "ATIVO"));
       qs.set("page", String(page));
       qs.set("perPage", String(perPage));
 
-      // tenta USERS_PATH; se falhar, tenta /usuarios
-      let res = await fetch(`${API_URL}${USERS_PATH}?${qs}`, {
-        headers,
-        cache: "no-store",
-      });
+      let res = await fetch(`${API_URL}${USERS_PATH}?${qs}`, { headers, cache: "no-store" });
       if (!res.ok) {
         const fallback = USERS_PATH === "/usuarios" ? "/auth/usuarios" : "/usuarios";
-        const res2 = await fetch(`${API_URL}${fallback}?${qs}`, {
-          headers,
-          cache: "no-store",
-        });
+        const res2 = await fetch(`${API_URL}${fallback}?${qs}`, { headers, cache: "no-store" });
         if (!res2.ok) {
           const text = await res2.text().catch(() => "");
           throw new Error(text || `Falha ao buscar alunos (${res2.status})`);
@@ -134,9 +114,6 @@ export default function AdminAlunosPage() {
 
       const json = await res.json();
       const usuarios: Usuario[] = Array.isArray(json) ? json : json.data ?? [];
-
-      // === FILTRO CLIENT-SIDE: somente alunos ===
-      // Regra: é aluno se papel === "USUARIO" OU se papel estiver ausente/null.
       const alunosApenas = usuarios.filter((u) => (u.papel ?? "USUARIO") === "USUARIO");
 
       const mapped: AlunoRow[] = alunosApenas.map((u) => ({
@@ -156,7 +133,6 @@ export default function AdminAlunosPage() {
 
       setRows(mapped);
       setTotal(totalCount);
-      // ao recarregar, limpa seleção (pra não ficar com IDs de outra página / filtro)
       setSelectedIds(new Set());
     } catch (e: unknown) {
       console.error(e);
@@ -175,8 +151,6 @@ export default function AdminAlunosPage() {
   }, [q, status, page]);
 
   function baixarModeloCSV() {
-    // - OBRIGATÓRIOS: ra, emailEducacional
-    // - OPCIONAIS: nome, emailPessoal, cursoNome, cursoSigla, ativo
     const headers = [
       "ra",
       "emailEducacional",
@@ -184,12 +158,22 @@ export default function AdminAlunosPage() {
       "emailPessoal",
       "cursoNome",
       "cursoSigla",
+      "unidadeFatec",
+      "turno",
+      "turma",
+      "semestreAtual",
+      "anoSemestreIngresso",
       "ativo",
     ];
 
     const exemploMinimo = [
       "123456",
       "joao.silva@fatec.sp.gov.br",
+      "",
+      "",
+      "",
+      "",
+      "",
       "",
       "",
       "",
@@ -204,10 +188,15 @@ export default function AdminAlunosPage() {
       "maria.souza@gmail.com",
       "Desenvolvimento de Software Multiplataforma",
       "DSM",
+      "Fatec Cotia",
+      "Manhã",
+      "DSM-3A",
+      "3",
+      "2023/1",
       "TRUE",
     ];
 
-    const rows = [headers, exemploMinimo, exemploCompleto]
+    const csvRows = [headers, exemploMinimo, exemploCompleto]
       .map((r) =>
         r
           .map((cell) => {
@@ -218,9 +207,7 @@ export default function AdminAlunosPage() {
       )
       .join("\n");
 
-    const blob = new Blob([`\uFEFF${rows}`], {
-      type: "text/csv;charset=utf-8",
-    });
+    const blob = new Blob([`﻿${csvRows}`], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -245,20 +232,15 @@ export default function AdminAlunosPage() {
     });
   }, [rows, q, status]);
 
-  // ===== seleção derivada =====
   const hasSelected = selectedIds.size > 0;
   const allVisibleSelected =
-    visibleRows.length > 0 &&
-    visibleRows.every((r) => selectedIds.has(r.id));
+    visibleRows.length > 0 && visibleRows.every((r) => selectedIds.has(r.id));
 
   function toggleSelectAllVisible(checked: boolean) {
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (checked) {
-        visibleRows.forEach((r) => next.add(r.id));
-      } else {
-        visibleRows.forEach((r) => next.delete(r.id));
-      }
+      if (checked) visibleRows.forEach((r) => next.add(r.id));
+      else visibleRows.forEach((r) => next.delete(r.id));
       return next;
     });
   }
@@ -275,48 +257,30 @@ export default function AdminAlunosPage() {
   async function handleDeleteSelected() {
     if (!hasSelected) return;
     const count = selectedIds.size;
-
     const confirmMsg =
       count === 1
         ? "Tem certeza que deseja excluir este aluno?"
         : `Tem certeza que deseja excluir ${count} alunos?`;
-
     if (!window.confirm(confirmMsg)) return;
 
     try {
       setDeleting(true);
-
       const token =
-        (typeof window !== "undefined" && localStorage.getItem("accessToken")) ||
-        "";
-
-      const headers: Record<string, string> = {
-        Accept: "application/json",
-      };
+        (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
+      const headers: Record<string, string> = { Accept: "application/json" };
       if (token) headers.Authorization = `Bearer ${token}`;
 
-      const idsArray = Array.from(selectedIds);
-
       const results = await Promise.allSettled(
-        idsArray.map((id) =>
-          // 👇 ajuste essa rota se o seu backend usar outro padrão (ex.: /auth/usuarios/:id ou /usuarios/:id/soft)
-          fetch(`${API_URL}/usuarios/${id}`, {
-            method: "DELETE",
-            headers,
-          }),
+        Array.from(selectedIds).map((id) =>
+          fetch(`${API_URL}/usuarios/${id}`, { method: "DELETE", headers }),
         ),
       );
 
       const failed = results.filter(
-        (r) =>
-          r.status === "rejected" ||
-          (r.status === "fulfilled" && !r.value.ok),
+        (r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok),
       );
-
       if (failed.length) {
-        alert(
-          `Alguns registros não puderam ser excluídos (${failed.length}/${idsArray.length}).`,
-        );
+        alert(`Alguns registros não puderam ser excluídos (${failed.length}/${selectedIds.size}).`);
       }
 
       setSelectedIds(new Set());
@@ -339,27 +303,20 @@ export default function AdminAlunosPage() {
         </div>
       )}
 
-      {/* ===== Modal: Importar CSV ===== */}
+      {/* Modal: Importar CSV */}
       {showImport && (
         <div className="fixed inset-0 z-50">
-          <div
-            className="absolute inset-0 bg-black/30"
-            onClick={() => setShowImport(false)}
-          />
-          <div className="absolute left-1/2 top-1/2 w-[92%] max-w-[880px] -translate-x-1/2 -translate-y-1/2 bg-background rounded-xl shadow-xl border border-[var(--border)] p-4">
+          <div className="absolute inset-0 bg-black/30" onClick={() => setShowImport(false)} />
+          <div className="absolute left-1/2 top-1/2 w-[92%] max-w-[960px] -translate-x-1/2 -translate-y-1/2 bg-background rounded-xl shadow-xl border border-[var(--border)] p-4">
             <ImportAlunos
               onClose={() => setShowImport(false)}
-              onDone={() => {
-                setShowImport(false);
-                setPage(1);
-                fetchAlunos();
-              }}
+              onDone={() => { setShowImport(false); setPage(1); fetchAlunos(); }}
             />
           </div>
         </div>
       )}
 
-      {/* ===== Form inline (toggle) ===== */}
+      {/* Form inline */}
       {showForm ? (
         <div className="rounded-xl border border-[var(--border)] bg-card p-4">
           <div className="flex items-center justify-between mb-4">
@@ -372,25 +329,19 @@ export default function AdminAlunosPage() {
             </button>
           </div>
           <FormAlunoCreate
-            onSuccess={() => {
-              setShowForm(false);
-              setPage(1);
-              fetchAlunos();
-            }}
+            onSuccess={() => { setShowForm(false); setPage(1); fetchAlunos(); }}
             onCancel={() => setShowForm(false)}
           />
         </div>
       ) : (
         <>
-          {/* ===== Toolbar ===== */}
+          {/* Toolbar */}
           <div className="rounded-xl border border-[var(--border)] bg-card p-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              {/* Ações à esquerda */}
               <div className="flex flex-wrap gap-2">
                 <button
                   onClick={() => setShowForm(true)}
                   className="inline-flex items-center gap-2 h-10 px-3 rounded-lg bg-primary text-primary-foreground text-sm hover:brightness-95"
-                  title="Cadastrar aluno (RA + e-mail educacional)"
                 >
                   <Plus className="size-4" />
                   Cadastrar aluno
@@ -399,7 +350,6 @@ export default function AdminAlunosPage() {
                   type="button"
                   onClick={() => setShowImport(true)}
                   className="inline-flex items-center gap-2 h-10 px-3 rounded-lg border border-[var(--border)] bg-background text-sm hover:bg-[var(--muted)]"
-                  title="Importar CSV"
                 >
                   <Upload className="size-4" />
                   Importar planilha
@@ -408,13 +358,11 @@ export default function AdminAlunosPage() {
                   type="button"
                   onClick={baixarModeloCSV}
                   className="inline-flex items-center gap-2 h-10 px-3 rounded-lg border border-[var(--border)] bg-background text-sm hover:bg-[var(--muted)]"
-                  title="Baixar modelo CSV (mínimo)"
+                  title="Baixar modelo CSV com todos os campos"
                 >
                   <Download className="size-4" />
                   Modelo CSV
                 </button>
-
-                {/* 👇 botão de excluir em massa */}
                 <button
                   type="button"
                   onClick={handleDeleteSelected}
@@ -425,60 +373,44 @@ export default function AdminAlunosPage() {
                       ? "border-destructive/40 text-destructive hover:bg-destructive/10"
                       : "border-[var(--border)] text-muted-foreground opacity-60 cursor-not-allowed",
                   )}
-                  title={
-                    hasSelected
-                      ? "Excluir alunos selecionados"
-                      : "Selecione pelo menos um aluno para excluir"
-                  }
                 >
                   <Trash2 className="size-4" />
                   {deleting ? "Excluindo..." : "Excluir selecionados"}
                 </button>
               </div>
 
-              {/* Filtros à direita */}
               <div className="flex w-full sm:w-auto flex-col gap-2 sm:flex-row">
                 <div className="relative sm:w-[320px]">
                   <Search className="size-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2" />
                   <input
-                    placeholder="Buscar por RA, e-mail educacional ou nome"
+                    placeholder="Buscar por RA, e-mail ou nome"
                     className="w-full h-10 rounded-lg border border-[var(--border)] bg-input px-9 focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
                     value={q}
-                    onChange={(e) => {
-                      setPage(1);
-                      setQ(e.target.value);
-                    }}
+                    onChange={(e) => { setPage(1); setQ(e.target.value); }}
                   />
                 </div>
-
-                <div className="flex gap-2">
-                  <div className="relative">
-                    <Filter className="size-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
-                    <select
-                      className="h-10 w-[160px] pl-9 pr-8 rounded-lg border border-[var(--border)] bg-background focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                      value={status}
-                      onChange={(e) => {
-                        setPage(1);
-                        setStatus(e.target.value as any);
-                      }}
-                    >
-                      <option value="ALL">Todos</option>
-                      <option value="ATIVO">Ativos</option>
-                      <option value="INATIVO">Inativos</option>
-                    </select>
-                  </div>
+                <div className="relative">
+                  <Filter className="size-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
+                  <select
+                    className="h-10 w-[160px] pl-9 pr-8 rounded-lg border border-[var(--border)] bg-background focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                    value={status}
+                    onChange={(e) => { setPage(1); setStatus(e.target.value as any); }}
+                  >
+                    <option value="ALL">Todos</option>
+                    <option value="ATIVO">Ativos</option>
+                    <option value="INATIVO">Inativos</option>
+                  </select>
                 </div>
               </div>
             </div>
           </div>
 
-          {/* ===== Tabela ===== */}
+          {/* Tabela */}
           <div className="rounded-xl border border-[var(--border)] bg-card overflow-hidden">
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm">
                 <thead className="bg-[var(--muted)] text-foreground/90">
                   <tr>
-                    {/* checkbox header */}
                     <th className="px-3 py-3 w-8">
                       <input
                         type="checkbox"
@@ -488,113 +420,79 @@ export default function AdminAlunosPage() {
                         aria-label="Selecionar todos desta página"
                       />
                     </th>
-                    <th className="text-left font-medium px-4 py-3 hidden xl:table-cell">
-                      RA
-                    </th>
-                    <th className="text-left font-medium px-4 py-3">
-                      E-mail educacional
-                    </th>
-                    <th className="text-left font-medium px-4 py-3 hidden md:table-cell">
-                      Nome (opcional)
-                    </th>
+                    <th className="text-left font-medium px-4 py-3 hidden xl:table-cell">RA</th>
+                    <th className="text-left font-medium px-4 py-3">E-mail educacional</th>
+                    <th className="text-left font-medium px-4 py-3 hidden md:table-cell">Nome</th>
                     <th className="text-left font-medium px-4 py-3">Status</th>
-                    <th className="text-left font-medium px-4 py-3 hidden lg:table-cell">
-                      Criado em
-                    </th>
+                    <th className="text-left font-medium px-4 py-3 hidden lg:table-cell">Criado em</th>
                     <th className="text-right font-medium px-4 py-3">Ações</th>
                   </tr>
                 </thead>
                 <tbody>
                   {loading && (
                     <tr>
-                      <td
-                        colSpan={7}
-                        className="px-4 py-6 text-center text-muted-foreground"
-                      >
+                      <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
                         Carregando...
                       </td>
                     </tr>
                   )}
 
-                  {!loading &&
-                    visibleRows.map((a) => (
-                      <tr
-                        key={a.id}
-                        className="border-t border-[var(--border)]"
-                      >
-                        {/* checkbox da linha */}
-                        <td className="px-3 py-3">
-                          <input
-                            type="checkbox"
-                            className="h-4 w-4 rounded border-[var(--border)]"
-                            checked={selectedIds.has(a.id)}
-                            onChange={(e) =>
-                              toggleSelectOne(a.id, e.target.checked)
-                            }
-                            aria-label={`Selecionar aluno RA ${a.ra}`}
-                          />
-                        </td>
-
-                        <td className="px-4 py-3 hidden xl:table-cell">
-                          <div className="inline-flex items-center gap-2">
-                            <IdCard className="size-4 text-muted-foreground" />
-                            <span className="font-medium">
-                              {a.ra || "—"}
-                            </span>
-                          </div>
-                        </td>
-
-                        <td className="px-4 py-3">
-                          <div className="flex items-center gap-2">
-                            <Mail className="size-4 text-muted-foreground" />
-                            <span>{a.emailEducacional}</span>
-                          </div>
-                          {/* Nome no mobile */}
-                          <div className="md:hidden text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
-                            <UserIcon className="size-3" />
-                            <span>{a.nome || "—"}</span>
-                          </div>
-                        </td>
-
-                        <td className="px-4 py-3 hidden md:table-cell">
-                          <div className="inline-flex items-center gap-2">
-                            <UserIcon className="size-4 text-muted-foreground" />
-                            <span>{a.nome || "—"}</span>
-                          </div>
-                        </td>
-
-                        <td className="px-4 py-3">
-                          <StatusBadge status={a.status} />
-                        </td>
-
-                        <td className="px-4 py-3 hidden lg:table-cell">
-                          {new Date(a.criadoEm).toLocaleDateString("pt-BR", {
-                            day: "2-digit",
-                            month: "2-digit",
-                            year: "numeric",
-                          })}
-                        </td>
-
-                        <td className="px-4 py-3 text-right">
-                          <Link
-                            href={`${ALUNO_DETAIL_PREFIX}${a.id}`}
-                            className="h-9 px-3 rounded-md hover:bg-[var(--muted)]"
-                          >
-                            Ver
-                          </Link>
-                        </td>
-                      </tr>
-                    ))}
+                  {!loading && visibleRows.map((a) => (
+                    <tr key={a.id} className="border-t border-[var(--border)]">
+                      <td className="px-3 py-3">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 rounded border-[var(--border)]"
+                          checked={selectedIds.has(a.id)}
+                          onChange={(e) => toggleSelectOne(a.id, e.target.checked)}
+                          aria-label={`Selecionar aluno RA ${a.ra}`}
+                        />
+                      </td>
+                      <td className="px-4 py-3 hidden xl:table-cell">
+                        <div className="inline-flex items-center gap-2">
+                          <IdCard className="size-4 text-muted-foreground" />
+                          <span className="font-medium">{a.ra || "—"}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <Mail className="size-4 text-muted-foreground" />
+                          <span>{a.emailEducacional}</span>
+                        </div>
+                        <div className="md:hidden text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+                          <UserIcon className="size-3" />
+                          <span>{a.nome || "—"}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 hidden md:table-cell">
+                        <div className="inline-flex items-center gap-2">
+                          <UserIcon className="size-4 text-muted-foreground" />
+                          <span>{a.nome || "—"}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusBadge status={a.status} />
+                      </td>
+                      <td className="px-4 py-3 hidden lg:table-cell">
+                        {new Date(a.criadoEm).toLocaleDateString("pt-BR", {
+                          day: "2-digit", month: "2-digit", year: "numeric",
+                        })}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <Link
+                          href={`${ALUNO_DETAIL_PREFIX}${a.id}`}
+                          className="h-9 px-3 rounded-md hover:bg-[var(--muted)]"
+                        >
+                          Ver
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
 
                   {!loading && visibleRows.length === 0 && (
                     <tr>
-                      <td
-                        colSpan={7}
-                        className="px-4 py-10 text-center text-muted-foreground"
-                      >
-                        {error
-                          ? "Falha ao carregar dados."
-                          : "Nenhum aluno encontrado com os filtros atuais."}
+                      <td colSpan={7} className="px-4 py-10 text-center text-muted-foreground">
+                        {error ? "Falha ao carregar dados." : "Nenhum aluno encontrado com os filtros atuais."}
                       </td>
                     </tr>
                   )}
@@ -602,42 +500,25 @@ export default function AdminAlunosPage() {
               </table>
             </div>
 
-            {/* ===== Footer (paginação) ===== */}
+            {/* Footer paginação */}
             <div className="flex items-center justify-between p-3 text-xs text-muted-foreground border-t border-[var(--border)]">
               <div>
                 {total ? (
-                  <>
-                    Mostrando {(page - 1) * perPage + 1}-
-                    {Math.min(page * perPage, total)} de {total}
-                  </>
+                  <>Mostrando {(page - 1) * perPage + 1}–{Math.min(page * perPage, total)} de {total}</>
                 ) : (
-                  <>
-                    Mostrando {visibleRows.length}
-                    {visibleRows.length === perPage ? "+" : ""}
-                  </>
+                  <>Mostrando {visibleRows.length}{visibleRows.length === perPage ? "+" : ""}</>
                 )}
               </div>
               <div className="inline-flex items-center gap-1">
                 <button
-                  className={cx(
-                    "h-8 px-2 rounded-md",
-                    prevEnabled
-                      ? "hover:bg-[var(--muted)]"
-                      : "opacity-50 cursor-not-allowed",
-                  )}
+                  className={cx("h-8 px-2 rounded-md", prevEnabled ? "hover:bg-[var(--muted)]" : "opacity-50 cursor-not-allowed")}
                   disabled={!prevEnabled}
                   onClick={() => setPage((p) => Math.max(1, p - 1))}
                 >
                   Anterior
                 </button>
-
                 <button
-                  className={cx(
-                    "h-8 px-2 rounded-md",
-                    nextEnabled
-                      ? "hover:bg-[var(--muted)]"
-                      : "opacity-50 cursor-not-allowed",
-                  )}
+                  className={cx("h-8 px-2 rounded-md", nextEnabled ? "hover:bg-[var(--muted)]" : "opacity-50 cursor-not-allowed")}
                   disabled={!nextEnabled}
                   onClick={() => setPage((p) => p + 1)}
                 >

--- a/app/(dashboard)/admin/relatorios/page.tsx
+++ b/app/(dashboard)/admin/relatorios/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Search, Filter, Download, RefreshCcw,
-  Clock, CheckCircle2, AlertTriangle, BarChart3, PieChart,
+  Clock, CheckCircle2, AlertTriangle, BarChart3, PieChart, Loader2,
 } from "lucide-react";
-import { cx } from '../../../../utils/cx'
+import { cx } from '../../../../utils/cx';
+import { apiFetch } from '../../../../utils/api';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 /* ===================== Tipos ===================== */
 type Status = "ABERTO" | "EM_ATENDIMENTO" | "AGUARDANDO_USUARIO" | "RESOLVIDO" | "ENCERRADO";
@@ -16,34 +19,32 @@ type Chamado = {
   id: string;
   protocolo?: string;
   titulo: string;
-  criadoEm: string;        // ISO
-  encerradoEm?: string;    // ISO | undefined
+  criadoEm: string;
+  encerradoEm?: string;
+  vencimentoSla?: string;
   status: Status;
   prioridade: Prioridade;
   nivel: Nivel;
   setor?: string | null;
   responsavel?: string | null;
-  slaDias?: number;        // SLA contratado (dias) - opcional
-  ttrHoras?: number;       // tempo total de resolução (horas) - opcional
-  tfsHoras?: number;       // tempo para primeira resposta (horas) - opcional
-  noPrazo?: boolean;       // se respeitou o SLA - opcional
 };
 
-/* ===================== MOCK ===================== */
-const MOCK: Chamado[] = [
-  { id: "1", protocolo: "WF-2025-0101", titulo: "Acesso ao SIGA", criadoEm: "2025-10-18T09:12:00Z", status: "ABERTO", prioridade: "ALTA", nivel: "N1", setor: "TI Acadêmica", responsavel: "Bruno", tfsHoras: 0.8 },
-  { id: "2", protocolo: "WF-2025-0102", titulo: "Erro boleto", criadoEm: "2025-10-16T15:38:00Z", status: "AGUARDANDO_USUARIO", prioridade: "MEDIA", nivel: "N2", setor: "Financeiro", responsavel: "Ana", tfsHoras: 1.5 },
-  { id: "3", protocolo: "WF-2025-0103", titulo: "Histórico escolar", criadoEm: "2025-10-14T11:05:00Z", status: "EM_ATENDIMENTO", prioridade: "BAIXA", nivel: "N1", setor: "Secretaria", responsavel: "Diego", tfsHoras: 3.2 },
-  { id: "4", protocolo: "WF-2025-0104", titulo: "SSO OIDC", criadoEm: "2025-10-13T08:21:00Z", status: "RESOLVIDO", prioridade: "URGENTE", nivel: "N3", setor: "TI Acadêmica", responsavel: "Carla", encerradoEm: "2025-10-14T09:00:00Z", ttrHoras: 24.7, tfsHoras: 0.6, slaDias: 3, noPrazo: true },
-  { id: "5", protocolo: "WF-2025-0105", titulo: "Alteração matrícula", criadoEm: "2025-10-12T08:21:00Z", status: "RESOLVIDO", prioridade: "MEDIA", nivel: "N2", setor: "Secretaria", responsavel: "Diego", encerradoEm: "2025-10-13T10:00:00Z", ttrHoras: 28.0, tfsHoras: 1.1, slaDias: 2, noPrazo: false },
-  { id: "6", protocolo: "WF-2025-0106", titulo: "Impressão carteirinha", criadoEm: "2025-10-12T12:00:00Z", status: "ENCERRADO", prioridade: "BAIXA", nivel: "N1", setor: "Secretaria", responsavel: "Luiza", encerradoEm: "2025-10-12T16:00:00Z", ttrHoras: 4, tfsHoras: 0.4, slaDias: 5, noPrazo: true },
-  { id: "7", protocolo: "WF-2025-0107", titulo: "Falha integração ERP", criadoEm: "2025-10-11T09:00:00Z", status: "EM_ATENDIMENTO", prioridade: "ALTA", nivel: "N3", setor: "Financeiro", responsavel: "Ana", tfsHoras: 2.0 },
-];
+type StatsData = {
+  total: number;
+  porStatus: Record<Status, number>;
+  porNivel: Record<Nivel, number>;
+  porPrioridade: Record<Prioridade, number>;
+  porSetor: Array<{ setorId: string; setorNome: string; total: number }>;
+  porResponsavel: Array<{ responsavelId: string; responsavelNome: string; total: number }>;
+  ttrMedioHoras: number;
+  slaMedioDias: number;
+  pctNoPrazo: number;
+  pctResolvidos: number;
+  tendencia7dias: Array<{ data: string; total: number }>;
+  atualizadoEm: string;
+};
 
 /* ===================== Utils ===================== */
-
-function parseISO(s: string) { return new Date(s).getTime(); }
-
 function toCSV(rows: Array<Record<string, any>>) {
   const headers = Object.keys(rows[0] ?? {});
   const escape = (v: any) => {
@@ -65,121 +66,166 @@ type Tab = "OVERVIEW" | "SLA" | "OPS";
 export default function RelatoriosPage() {
   const [tab, setTab] = useState<Tab>("OVERVIEW");
 
-  // filtros
   const [q, setQ] = useState("");
-  const [status, setStatus] = useState<Status | "ALL">("ALL");
+  const [statusFiltro, setStatusFiltro] = useState<Status | "ALL">("ALL");
   const [prioridade, setPrioridade] = useState<Prioridade | "ALL">("ALL");
   const [nivel, setNivel] = useState<Nivel | "ALL">("ALL");
   const [setor, setSetor] = useState<string | "ALL">("ALL");
-  const [dtIni, setDtIni] = useState<string>(""); // yyyy-mm-dd
-  const [dtFim, setDtFim] = useState<string>(""); // yyyy-mm-dd
+  const [dtIni, setDtIni] = useState<string>("");
+  const [dtFim, setDtFim] = useState<string>("");
 
-  const setoresDisponiveis = useMemo(() => {
-    const s = new Set(MOCK.map(c => c.setor).filter(Boolean) as string[]);
-    return Array.from(s).sort();
+  const [stats, setStats] = useState<StatsData | null>(null);
+  const [tickets, setTickets] = useState<Chamado[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [statsRes, ticketsRes] = await Promise.all([
+        apiFetch(`${API_BASE}/tickets/stats`),
+        apiFetch(`${API_BASE}/tickets?pageSize=100&include=setor,responsavel`),
+      ]);
+
+      if (statsRes.ok) {
+        const json = await statsRes.json();
+        setStats(json);
+      }
+
+      if (ticketsRes.ok) {
+        const json = await ticketsRes.json();
+        const list = Array.isArray(json) ? json : (json.data ?? []);
+        setTickets(
+          list.map((t: any) => ({
+            id: t.id,
+            protocolo: t.protocolo,
+            titulo: t.titulo ?? t.assunto ?? "—",
+            criadoEm: t.criadoEm,
+            encerradoEm: t.encerradoEm ?? undefined,
+            vencimentoSla: t.vencimentoSla ?? undefined,
+            status: t.status,
+            prioridade: t.prioridade,
+            nivel: t.nivel,
+            setor: t.setor?.nome ?? t.setorNome ?? (typeof t.setor === "string" ? t.setor : null),
+            responsavel:
+              t.responsavel?.nome ??
+              t.responsavelNome ??
+              (typeof t.responsavel === "string" ? t.responsavel : null),
+          }))
+        );
+      }
+
+      setLastUpdated(new Date());
+      setError(null);
+    } catch (e: any) {
+      setError(e?.message ?? "Erro ao carregar dados");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const dados = useMemo(() => {
-    return MOCK.filter((c) => {
+  useEffect(() => {
+    fetchData();
+    const id = setInterval(fetchData, 30_000);
+    return () => clearInterval(id);
+  }, [fetchData]);
+
+  const setoresDisponiveis = useMemo(() => {
+    if (!stats) return [];
+    return stats.porSetor.map((s) => s.setorNome).sort();
+  }, [stats]);
+
+  const dadosFiltrados = useMemo(() => {
+    return tickets.filter((c) => {
       const matchQ =
         !q ||
         c.titulo.toLowerCase().includes(q.toLowerCase()) ||
         c.protocolo?.toLowerCase().includes(q.toLowerCase()) ||
         c.responsavel?.toLowerCase().includes(q.toLowerCase()) ||
         c.setor?.toLowerCase().includes(q.toLowerCase());
-      const matchS = status === "ALL" || c.status === status;
+      const matchS = statusFiltro === "ALL" || c.status === statusFiltro;
       const matchP = prioridade === "ALL" || c.prioridade === prioridade;
       const matchN = nivel === "ALL" || c.nivel === nivel;
       const matchSetor = setor === "ALL" || c.setor === setor;
-
-      const matchDataIni = !dtIni || parseISO(c.criadoEm) >= parseISO(`${dtIni}T00:00:00`);
-      const matchDataFim = !dtFim || parseISO(c.criadoEm) <= parseISO(`${dtFim}T23:59:59`);
-
+      const ts = new Date(c.criadoEm).getTime();
+      const matchDataIni = !dtIni || ts >= new Date(`${dtIni}T00:00:00`).getTime();
+      const matchDataFim = !dtFim || ts <= new Date(`${dtFim}T23:59:59`).getTime();
       return matchQ && matchS && matchP && matchN && matchSetor && matchDataIni && matchDataFim;
     });
-  }, [q, status, prioridade, nivel, setor, dtIni, dtFim]);
+  }, [tickets, q, statusFiltro, prioridade, nivel, setor, dtIni, dtFim]);
 
-  /* ===== KPIs ===== */
   const kpis = useMemo(() => {
-    const total = dados.length;
-    const abertos = dados.filter(d => d.status === "ABERTO").length;
-    const atendimento = dados.filter(d => d.status === "EM_ATENDIMENTO").length;
-    const aguardUser = dados.filter(d => d.status === "AGUARDANDO_USUARIO").length;
-    const resolvidos = dados.filter(d => d.status === "RESOLVIDO" || d.status === "ENCERRADO").length;
+    if (!stats) return { total: 0, abertos: 0, atendimento: 0, aguardUser: 0, resolvidos: 0, ttrMedio: 0, slaMedioDias: 0, pctNoPrazo: 0, pctResolvidos: 0 };
+    return {
+      total: stats.total,
+      abertos: stats.porStatus.ABERTO ?? 0,
+      atendimento: stats.porStatus.EM_ATENDIMENTO ?? 0,
+      aguardUser: stats.porStatus.AGUARDANDO_USUARIO ?? 0,
+      resolvidos: (stats.porStatus.RESOLVIDO ?? 0) + (stats.porStatus.ENCERRADO ?? 0),
+      ttrMedio: stats.ttrMedioHoras ?? 0,
+      slaMedioDias: stats.slaMedioDias ?? 0,
+      pctNoPrazo: stats.pctNoPrazo ?? 0,
+      pctResolvidos: stats.pctResolvidos ?? 0,
+    };
+  }, [stats]);
 
-    const resolvidosComTTR = dados.filter(d => d.ttrHoras != null);
-    const ttrMedio = resolvidosComTTR.length
-      ? (resolvidosComTTR.reduce((acc, d) => acc + (d.ttrHoras ?? 0), 0) / resolvidosComTTR.length)
-      : 0;
-
-    const tfsComValor = dados.filter(d => d.tfsHoras != null);
-    const tfsMedio = tfsComValor.length
-      ? (tfsComValor.reduce((acc, d) => acc + (d.tfsHoras ?? 0), 0) / tfsComValor.length)
-      : 0;
-
-    const temSLA = dados.filter(d => d.noPrazo != null);
-    const pctNoPrazo = temSLA.length
-      ? Math.round(100 * (temSLA.filter(d => d.noPrazo).length / temSLA.length))
-      : 0;
-
-    return { total, abertos, atendimento, aguardUser, resolvidos, ttrMedio, tfsMedio, pctNoPrazo };
-  }, [dados]);
-
-  /* ===== Agregados ===== */
   const porSetor = useMemo(() => {
-    const map: Record<string, number> = {};
-    for (const d of dados) {
-      const key = d.setor ?? "—";
-      map[key] = (map[key] ?? 0) + 1;
-    }
-    const total = Object.values(map).reduce((a, b) => a + b, 0) || 1;
-    return Object.entries(map).map(([setor, qtd]) => ({ setor, qtd, pct: Math.round((qtd / total) * 100) }));
-  }, [dados]);
+    if (!stats) return [];
+    const total = stats.porSetor.reduce((a, b) => a + b.total, 0) || 1;
+    return stats.porSetor.map((s) => ({
+      setor: s.setorNome,
+      qtd: s.total,
+      pct: Math.round((s.total / total) * 100),
+    }));
+  }, [stats]);
 
   const porNivel = useMemo(() => {
+    if (!stats) return [];
     const keys: Nivel[] = ["N1", "N2", "N3"];
-    return keys.map(n => ({ nivel: n, qtd: dados.filter(d => d.nivel === n).length }));
-  }, [dados]);
+    return keys.map((n) => ({ nivel: n, qtd: stats.porNivel[n] ?? 0 }));
+  }, [stats]);
 
   const porPrioridade = useMemo(() => {
+    if (!stats) return [];
     const keys: Prioridade[] = ["BAIXA", "MEDIA", "ALTA", "URGENTE"];
-    return keys.map(p => ({ prioridade: p, qtd: dados.filter(d => d.prioridade === p).length }));
-  }, [dados]);
+    return keys.map((p) => ({ prioridade: p, qtd: stats.porPrioridade[p] ?? 0 }));
+  }, [stats]);
 
   const porTecnico = useMemo(() => {
-    const map: Record<string, number> = {};
-    for (const d of dados) {
-      const key = d.responsavel ?? "—";
-      map[key] = (map[key] ?? 0) + 1;
-    }
-    return Object.entries(map).map(([responsavel, qtd]) => ({ responsavel, qtd }))
+    if (!stats) return [];
+    return stats.porResponsavel
+      .map((r) => ({ responsavel: r.responsavelNome, qtd: r.total }))
       .sort((a, b) => b.qtd - a.qtd);
-  }, [dados]);
+  }, [stats]);
 
   const slaPorSetor = useMemo(() => {
-    // média de TTR por setor + % no prazo
     const map: Record<string, { total: number; somaTTR: number; comSLA: number; noPrazo: number }> = {};
-    for (const d of dados) {
+    for (const d of tickets) {
       const key = d.setor ?? "—";
       map[key] = map[key] || { total: 0, somaTTR: 0, comSLA: 0, noPrazo: 0 };
       map[key].total += 1;
-      if (d.ttrHoras != null) map[key].somaTTR += d.ttrHoras;
-      if (d.noPrazo != null) {
+      if (d.encerradoEm && d.criadoEm) {
+        const ttr = (new Date(d.encerradoEm).getTime() - new Date(d.criadoEm).getTime()) / 3_600_000;
+        map[key].somaTTR += ttr;
+      }
+      if (d.vencimentoSla && d.encerradoEm) {
         map[key].comSLA += 1;
-        if (d.noPrazo) map[key].noPrazo += 1;
+        if (new Date(d.encerradoEm) <= new Date(d.vencimentoSla)) map[key].noPrazo += 1;
       }
     }
-    return Object.entries(map).map(([setor, v]) => ({
-      setor,
-      ttrMedio: v.somaTTR && v.total ? +(v.somaTTR / v.total).toFixed(1) : 0,
-      pctNoPrazo: v.comSLA ? Math.round(100 * (v.noPrazo / v.comSLA)) : 0,
-      total: v.total,
-    })).sort((a, b) => b.total - a.total);
-  }, [dados]);
+    return Object.entries(map)
+      .map(([s, v]) => ({
+        setor: s,
+        ttrMedio: v.somaTTR && v.total ? +(v.somaTTR / v.total).toFixed(1) : 0,
+        pctNoPrazo: v.comSLA ? Math.round(100 * (v.noPrazo / v.comSLA)) : 0,
+        total: v.total,
+      }))
+      .sort((a, b) => b.total - a.total);
+  }, [tickets]);
 
   function exportarCSV() {
-    if (dados.length === 0) return;
-    const rows = dados.map(d => ({
+    if (dadosFiltrados.length === 0) return;
+    const rows = dadosFiltrados.map((d) => ({
       id: d.id,
       protocolo: d.protocolo ?? "",
       titulo: d.titulo,
@@ -190,15 +236,25 @@ export default function RelatoriosPage() {
       nivel: d.nivel,
       setor: d.setor ?? "",
       responsavel: d.responsavel ?? "",
-      ttrHoras: d.ttrHoras ?? "",
-      tfsHoras: d.tfsHoras ?? "",
-      noPrazo: d.noPrazo ?? "",
     }));
     toCSV(rows);
   }
 
   return (
     <div className="space-y-6">
+      {/* Barra de status */}
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          {loading && <Loader2 className="size-4 animate-spin" />}
+          {error && <span className="text-destructive">{error}</span>}
+        </div>
+        {lastUpdated && (
+          <span>
+            Última atualização: {lastUpdated.toLocaleTimeString("pt-BR")} · atualiza a cada 30s
+          </span>
+        )}
+      </div>
+
       {/* Toolbar de filtros */}
       <div className="rounded-xl border border-[var(--border)] bg-card p-4">
         <div className="grid grid-cols-1 gap-3 lg:grid-cols-12">
@@ -226,8 +282,8 @@ export default function RelatoriosPage() {
               <Filter className="size-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
               <select
                 className="h-10 w-full pl-9 pr-8 rounded-lg border border-[var(--border)] bg-background"
-                value={status}
-                onChange={(e) => setStatus(e.target.value as any)}
+                value={statusFiltro}
+                onChange={(e) => setStatusFiltro(e.target.value as any)}
               >
                 <option value="ALL">Todos os status</option>
                 <option value="ABERTO">Aberto</option>
@@ -280,7 +336,6 @@ export default function RelatoriosPage() {
           </div>
         </div>
 
-        {/* Ações */}
         <div className="mt-3 flex items-center gap-2">
           <button
             type="button"
@@ -291,7 +346,7 @@ export default function RelatoriosPage() {
           </button>
           <button
             type="button"
-            onClick={() => {/* poderia reconsultar backend */}}
+            onClick={() => { setLoading(true); fetchData(); }}
             className="inline-flex items-center gap-2 h-9 px-3 rounded-md border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
           >
             <RefreshCcw className="size-4" /> Atualizar
@@ -301,12 +356,12 @@ export default function RelatoriosPage() {
 
       {/* KPIs */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-4">
-        <Kpi icon={<BarChart3 className="size-4" />} label="Total" value={dados.length} />
-        <Kpi icon={<AlertTriangle className="size-4" />} label="Abertos" value={kpis.abertos} tone="brand-cyan" />
-        <Kpi icon={<Clock className="size-4" />} label="Em atendimento" value={kpis.atendimento} tone="brand-teal" />
-        <Kpi icon={<Clock className="size-4" />} label="Aguard. usuário" value={kpis.aguardUser} tone="warning" />
-        <Kpi icon={<CheckCircle2 className="size-4" />} label="Resolvidos/Encerr." value={kpis.resolvidos} tone="success" />
-        <Kpi icon={<PieChart className="size-4" />} label="% no prazo (SLA)" value={`${kpis.pctNoPrazo}%`} />
+        <Kpi icon={<BarChart3 className="size-4" />} label="Total" value={kpis.total} loading={loading} />
+        <Kpi icon={<AlertTriangle className="size-4" />} label="Abertos" value={kpis.abertos} tone="brand-cyan" loading={loading} />
+        <Kpi icon={<Clock className="size-4" />} label="Em atendimento" value={kpis.atendimento} tone="brand-teal" loading={loading} />
+        <Kpi icon={<Clock className="size-4" />} label="Aguard. usuário" value={kpis.aguardUser} tone="warning" loading={loading} />
+        <Kpi icon={<CheckCircle2 className="size-4" />} label="Resolvidos/Encerr." value={kpis.resolvidos} tone="success" loading={loading} />
+        <Kpi icon={<PieChart className="size-4" />} label="% no prazo (SLA)" value={`${kpis.pctNoPrazo}%`} loading={loading} />
       </div>
 
       {/* Tabs */}
@@ -320,21 +375,21 @@ export default function RelatoriosPage() {
         <section className="grid grid-cols-1 xl:grid-cols-12 gap-6">
           <Card title="Distribuição por Setor" className="xl:col-span-7">
             <BarTable
-              rows={porSetor.map(r => ({ label: r.setor, value: r.qtd, suffix: ` (${r.pct}%)` }))}
+              rows={porSetor.map((r) => ({ label: r.setor, value: r.qtd, suffix: ` (${r.pct}%)` }))}
               total={porSetor.reduce((a, b) => a + b.qtd, 0)}
             />
           </Card>
 
           <Card title="Por Nível / Prioridade" className="xl:col-span-5">
             <div className="grid grid-cols-2 gap-4">
-              <MiniBar title="Por Nível" rows={porNivel.map(x => ({ label: x.nivel, value: x.qtd }))} />
-              <MiniBar title="Por Prioridade" rows={porPrioridade.map(x => ({ label: x.prioridade, value: x.qtd }))} />
+              <MiniBar title="Por Nível" rows={porNivel.map((x) => ({ label: x.nivel, value: x.qtd }))} />
+              <MiniBar title="Por Prioridade" rows={porPrioridade.map((x) => ({ label: x.prioridade, value: x.qtd }))} />
             </div>
           </Card>
 
           <Card title="Por Responsável (Top)" className="xl:col-span-12">
             <BarTable
-              rows={porTecnico.map(r => ({ label: r.responsavel, value: r.qtd }))}
+              rows={porTecnico.map((r) => ({ label: r.responsavel, value: r.qtd }))}
               total={porTecnico.reduce((a, b) => a + b.qtd, 0)}
             />
           </Card>
@@ -345,7 +400,7 @@ export default function RelatoriosPage() {
         <section className="grid grid-cols-1 xl:grid-cols-12 gap-6">
           <Card title="Tempo médio de resolução (h) por Setor" className="xl:col-span-7">
             <BarTable
-              rows={slaPorSetor.map(x => ({ label: x.setor, value: x.ttrMedio, suffix: " h" }))}
+              rows={slaPorSetor.map((x) => ({ label: x.setor, value: x.ttrMedio, suffix: " h" }))}
               total={slaPorSetor.reduce((a, b) => a + b.ttrMedio, 0)}
               normalizeByMax
             />
@@ -354,7 +409,7 @@ export default function RelatoriosPage() {
           <Card title="% no prazo (SLA) por Setor" className="xl:col-span-5">
             <MiniBar
               title="No prazo (SLA)"
-              rows={slaPorSetor.map(x => ({ label: x.setor, value: x.pctNoPrazo }))}
+              rows={slaPorSetor.map((x) => ({ label: x.setor, value: x.pctNoPrazo }))}
               valueSuffix="%"
               clamp100
             />
@@ -363,7 +418,7 @@ export default function RelatoriosPage() {
           <Card title="Tempos médios" className="xl:col-span-12">
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <Stat label="TTR médio (h)" value={kpis.ttrMedio ? kpis.ttrMedio.toFixed(1) : "—"} />
-              <Stat label="TFS médio (h)" value={kpis.tfsMedio ? kpis.tfsMedio.toFixed(1) : "—"} />
+              <Stat label="SLA médio (dias)" value={kpis.slaMedioDias ? kpis.slaMedioDias.toFixed(1) : "—"} />
               <Stat label="% no prazo (SLA)" value={`${kpis.pctNoPrazo}%`} />
             </div>
           </Card>
@@ -375,25 +430,22 @@ export default function RelatoriosPage() {
           <Card title="Fila atual por status" className="xl:col-span-6">
             <MiniBar
               rows={[
-                { label: "Aberto", value: dados.filter(d => d.status === "ABERTO").length },
-                { label: "Em atendimento", value: dados.filter(d => d.status === "EM_ATENDIMENTO").length },
-                { label: "Aguard. usuário", value: dados.filter(d => d.status === "AGUARDANDO_USUARIO").length },
-                { label: "Resolvido/Encerr.", value: dados.filter(d => d.status === "RESOLVIDO" || d.status === "ENCERRADO").length },
+                { label: "Aberto", value: kpis.abertos },
+                { label: "Em atendimento", value: kpis.atendimento },
+                { label: "Aguard. usuário", value: kpis.aguardUser },
+                { label: "Resolvido/Encerr.", value: kpis.resolvidos },
               ]}
             />
           </Card>
           <Card title="Backlog por Nível" className="xl:col-span-6">
-            <MiniBar
-              rows={[
-                { label: "N1", value: dados.filter(d => d.nivel === "N1" && d.status !== "RESOLVIDO" && d.status !== "ENCERRADO").length },
-                { label: "N2", value: dados.filter(d => d.nivel === "N2" && d.status !== "RESOLVIDO" && d.status !== "ENCERRADO").length },
-                { label: "N3", value: dados.filter(d => d.nivel === "N3" && d.status !== "RESOLVIDO" && d.status !== "ENCERRADO").length },
-              ]}
-            />
+            <MiniBar rows={porNivel.map((x) => ({ label: x.nivel, value: x.qtd }))} />
           </Card>
 
-          <Card title="Detalhes (dados filtrados)" className="xl:col-span-12">
-            <DataTable dados={dados} />
+          <Card
+            title={`Detalhes — ${dadosFiltrados.length} chamado${dadosFiltrados.length !== 1 ? "s" : ""} (com filtros aplicados)`}
+            className="xl:col-span-12"
+          >
+            <DataTable dados={dadosFiltrados} />
           </Card>
         </section>
       )}
@@ -402,9 +454,10 @@ export default function RelatoriosPage() {
 }
 
 /* ===================== Componentes UI ===================== */
-function Kpi({ icon, label, value, tone }: {
+function Kpi({ icon, label, value, tone, loading }: {
   icon: React.ReactNode; label: string; value: number | string;
   tone?: "brand-cyan" | "brand-teal" | "warning" | "success";
+  loading?: boolean;
 }) {
   const bg: Record<string, string> = {
     "brand-cyan": "bg-[var(--brand-cyan)]/10",
@@ -423,9 +476,12 @@ function Kpi({ icon, label, value, tone }: {
       <div className="flex items-center justify-between">
         <div className="space-y-1">
           <div className="text-sm text-muted-foreground">{label}</div>
-          <div className="text-2xl font-semibold">{value}</div>
+          {loading
+            ? <div className="h-8 w-16 rounded bg-[var(--muted)] animate-pulse" />
+            : <div className="text-2xl font-semibold">{value}</div>
+          }
         </div>
-        <div className={cx("size-10 rounded-lg grid place-items-center", tone ? bg[tone] : "bg-[var(--muted)]")}>
+        <div className={cx("size-10 rounded-lg grid place-items-center", tone ? bg[tone] : "bg-[var(--muted)]") }>
           <div className={cx("opacity-90", tone ? fg[tone] : "text-muted-foreground")}>{icon}</div>
         </div>
       </div>
@@ -468,7 +524,7 @@ function BarTable({ rows, total, normalizeByMax = false }: {
   total: number;
   normalizeByMax?: boolean;
 }) {
-  const max = Math.max(...rows.map(r => r.value), 1);
+  const max = Math.max(...rows.map((r) => r.value), 1);
   return (
     <div className="space-y-3">
       {rows.map((r) => (
@@ -479,7 +535,7 @@ function BarTable({ rows, total, normalizeByMax = false }: {
           </div>
           <div className="col-span-2 text-right text-sm">
             <span className="font-medium">{r.value}</span>
-            {r.suffix && <span className="text-muted-foreground"> {r.suffix}</span>}
+            {r.suffix && <span className="text-muted-foreground">{r.suffix}</span>}
           </div>
         </div>
       ))}
@@ -496,7 +552,7 @@ function MiniBar({ title, rows, valueSuffix = "", clamp100 = false }: {
   valueSuffix?: string;
   clamp100?: boolean;
 }) {
-  const max = Math.max(...rows.map(r => r.value), 1);
+  const max = Math.max(...rows.map((r) => r.value), 1);
   return (
     <div>
       {title && <div className="text-xs uppercase tracking-wide text-muted-foreground mb-2">{title}</div>}
@@ -548,15 +604,12 @@ function DataTable({ dados }: { dados: Chamado[] }) {
               <th className="text-left font-medium px-4 py-3 hidden lg:table-cell">Resp.</th>
               <th className="text-left font-medium px-4 py-3 hidden lg:table-cell">Criado em</th>
               <th className="text-left font-medium px-4 py-3 hidden lg:table-cell">Encerrado em</th>
-              <th className="text-left font-medium px-4 py-3 hidden xl:table-cell">TFS (h)</th>
-              <th className="text-left font-medium px-4 py-3 hidden xl:table-cell">TTR (h)</th>
-              <th className="text-left font-medium px-4 py-3 hidden xl:table-cell">SLA</th>
             </tr>
           </thead>
           <tbody>
             {dados.map((c) => (
               <tr key={c.id} className="border-t border-[var(--border)]">
-                <td className="px-4 py-3 font-medium">{c.protocolo ?? `#${c.id}`}</td>
+                <td className="px-4 py-3 font-medium">{c.protocolo ?? `#${c.id.slice(0, 8)}`}</td>
                 <td className="px-4 py-3 max-w-[380px]"><div className="line-clamp-1">{c.titulo}</div></td>
                 <td className="px-4 py-3 hidden md:table-cell">{c.setor ?? "—"}</td>
                 <td className="px-4 py-3">{c.nivel}</td>
@@ -571,16 +624,11 @@ function DataTable({ dados }: { dados: Chamado[] }) {
                     ? new Date(c.encerradoEm).toLocaleString("pt-BR", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })
                     : "—"}
                 </td>
-                <td className="px-4 py-3 hidden xl:table-cell">{c.tfsHoras ?? "—"}</td>
-                <td className="px-4 py-3 hidden xl:table-cell">{c.ttrHoras ?? "—"}</td>
-                <td className="px-4 py-3 hidden xl:table-cell">
-                  {c.noPrazo == null ? "—" : c.noPrazo ? "No prazo" : "Fora do prazo"}
-                </td>
               </tr>
             ))}
             {dados.length === 0 && (
               <tr>
-                <td colSpan={12} className="px-4 py-10 text-center text-muted-foreground">
+                <td colSpan={9} className="px-4 py-10 text-center text-muted-foreground">
                   Sem dados com os filtros atuais.
                 </td>
               </tr>

--- a/app/(dashboard)/aluno/configuracoes/page.tsx
+++ b/app/(dashboard)/aluno/configuracoes/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Bell, Globe, Loader2, Moon, Save, Settings, Sun, Trash2 } from "lucide-react";
+import { Bell, Globe, Loader2, Moon, RotateCcw, Save, Settings, Sun } from "lucide-react";
 import { toast } from "sonner";
 import MobileSidebarTriggerAluno from "../_components/MobileSidebarTriggerAluno";
 import { cx } from "../../../../utils/cx";
 
 const LS_KEYS = {
   theme: "theme",
-  lang: "lang",
   emailNotif: "email_notifications",
 } as const;
 
@@ -16,76 +15,69 @@ function getInitialTheme(): "light" | "dark" {
   if (typeof window === "undefined") return "light";
   const stored = localStorage.getItem(LS_KEYS.theme) as "light" | "dark" | null;
   if (stored === "light" || stored === "dark") return stored;
-  const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches;
-  return prefersDark ? "dark" : "light";
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onChange}
+      className={cx(
+        "relative inline-flex h-5 w-10 shrink-0 cursor-pointer rounded-full transition-colors",
+        checked ? "bg-primary" : "bg-[var(--muted)]"
+      )}
+    >
+      <span
+        className={cx(
+          "absolute top-[2px] left-[2px] h-4 w-4 rounded-full bg-background shadow transition-transform",
+          checked ? "translate-x-5" : "translate-x-0"
+        )}
+      />
+    </button>
+  );
 }
 
 export default function ConfiguracoesAlunoPage() {
   const [saving, setSaving] = useState(false);
   const [theme, setTheme] = useState<"light" | "dark">(getInitialTheme);
-  const [lang, setLang] = useState<string>("pt-BR");
-  const [emailNotif, setEmailNotif] = useState<boolean>(true); // default ligado
+  const [platNotif, setPlatNotif] = useState<boolean>(true);
 
-  // carrega lang / emailNotif do localStorage só no cliente
   useEffect(() => {
     if (typeof window === "undefined") return;
-
-    const storedLang = localStorage.getItem(LS_KEYS.lang);
-    if (storedLang) {
-      setLang(storedLang);
-    }
-
     const v = localStorage.getItem(LS_KEYS.emailNotif);
-    if (v !== null) {
-      setEmailNotif(v === "1");
-    }
+    if (v !== null) setPlatNotif(v === "1");
   }, []);
 
-  // aplica o tema no <html> e persiste
   useEffect(() => {
-    if (typeof window === "undefined" || typeof document === "undefined") return;
-
+    if (typeof window === "undefined") return;
     const root = document.documentElement;
     if (theme === "dark") root.classList.add("dark");
     else root.classList.remove("dark");
-
     localStorage.setItem(LS_KEYS.theme, theme);
   }, [theme]);
 
-  function handleThemeToggle() {
-    setTheme((t) => (t === "dark" ? "light" : "dark"));
-  }
-
-  function handleClearCache() {
+  function handleRestoreDefaults() {
     if (typeof window === "undefined") return;
-
-    // limpa apenas as chaves locais desta página
     localStorage.removeItem(LS_KEYS.theme);
-    localStorage.removeItem(LS_KEYS.lang);
     localStorage.removeItem(LS_KEYS.emailNotif);
-    toast.info("Preferências locais limpas!");
-
-    // re-aplica defaults
-    setTheme(getInitialTheme());
-    setLang("pt-BR");
-    setEmailNotif(true);
+    const defaultTheme = window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    setTheme(defaultTheme);
+    setPlatNotif(true);
+    toast.info("Preferências restauradas para o padrão.");
   }
 
   async function saveConfig(e: React.FormEvent) {
     e.preventDefault();
     try {
       setSaving(true);
-
       if (typeof window !== "undefined") {
-        // persistência local
-        localStorage.setItem(LS_KEYS.lang, lang);
-        localStorage.setItem(LS_KEYS.emailNotif, emailNotif ? "1" : "0");
+        localStorage.setItem(LS_KEYS.emailNotif, platNotif ? "1" : "0");
       }
-
-      // futuro: chamada pro backend (/me/preferences)
-
-      toast.success("Configurações salvas com sucesso!");
-    } catch (e) {
+      toast.success("Configurações salvas!");
+    } catch {
       toast.error("Falha ao salvar configurações");
     } finally {
       setSaving(false);
@@ -94,12 +86,10 @@ export default function ConfiguracoesAlunoPage() {
 
   return (
     <div className="space-y-6">
-      {/* Topbar mínima (sem saudação; o layout já tem cabeçalho global) */}
       <div className="mb-2 flex items-center justify-end">
         <MobileSidebarTriggerAluno />
       </div>
 
-      {/* Form */}
       <form
         onSubmit={saveConfig}
         className="rounded-xl border border-[var(--border)] bg-card p-5 sm:p-6 grid gap-6"
@@ -110,97 +100,81 @@ export default function ConfiguracoesAlunoPage() {
         </div>
 
         {/* Tema */}
-        <div className="flex items-center justify-between border-b border-[var(--border)] pb-3">
+        <div className="flex items-center justify-between border-b border-[var(--border)] pb-5">
           <div className="flex items-center gap-3">
-            {theme === "dark" ? (
-              <Moon className="size-5 text-muted-foreground" />
-            ) : (
-              <Sun className="size-5 text-muted-foreground" />
-            )}
+            {theme === "dark"
+              ? <Moon className="size-5 text-muted-foreground" />
+              : <Sun className="size-5 text-muted-foreground" />}
             <div>
               <div className="font-medium">Tema escuro</div>
               <div className="text-sm text-muted-foreground">
-                Altere entre o modo claro e escuro da interface.
+                Alterna entre o modo claro e escuro da interface.
               </div>
             </div>
           </div>
-          <label className="inline-flex cursor-pointer items-center">
-            <input
-              type="checkbox"
-              className="sr-only peer"
-              checked={theme === "dark"}
-              onChange={handleThemeToggle}
-            />
-            <div className="w-10 h-5 bg-[var(--muted)] rounded-full peer peer-checked:bg-primary transition-all relative">
-              <span className="absolute top-[2px] left-[2px] w-4 h-4 bg-background rounded-full transition-all peer-checked:translate-x-5" />
-            </div>
-          </label>
+          <Toggle checked={theme === "dark"} onChange={() => setTheme((t) => t === "dark" ? "light" : "dark")} />
         </div>
 
         {/* Idioma */}
-        <div className="flex items-center justify-between border-b border-[var(--border)] pb-3">
+        <div className="flex items-center justify-between border-b border-[var(--border)] pb-5">
           <div className="flex items-center gap-3">
             <Globe className="size-5 text-muted-foreground" />
             <div>
-              <div className="font-medium">Idioma</div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">Idioma</span>
+                <span className="rounded-md border border-[var(--border)] bg-[var(--muted)] px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                  em breve
+                </span>
+              </div>
               <div className="text-sm text-muted-foreground">
-                Escolha o idioma da interface e das notificações.
+                O sistema está disponível apenas em Português (Brasil).
               </div>
             </div>
           </div>
           <select
-            className="h-9 rounded-lg border border-[var(--border)] bg-input px-3 focus:outline-none focus:ring-2 focus:ring-[var(--ring)] text-sm"
-            value={lang}
-            onChange={(e) => setLang(e.target.value)}
+            disabled
+            className="h-9 rounded-lg border border-[var(--border)] bg-input px-3 text-sm opacity-50 cursor-not-allowed"
+            value="pt-BR"
           >
             <option value="pt-BR">Português (Brasil)</option>
-            <option value="en-US">English (US)</option>
-            <option value="es-ES">Español</option>
           </select>
         </div>
 
-        {/* Notificações */}
-        <div className="flex items-center justify-between border-b border-[var(--border)] pb-3">
+        {/* Notificações na plataforma */}
+        <div className="flex items-center justify-between border-b border-[var(--border)] pb-5">
           <div className="flex items-center gap-3">
             <Bell className="size-5 text-muted-foreground" />
             <div>
-              <div className="font-medium">Notificações por e-mail</div>
+              <div className="font-medium">Notificações na plataforma</div>
               <div className="text-sm text-muted-foreground">
-                Receba alertas sobre atualizações de solicitações acadêmicas e mensagens.
+                Receba alertas sobre atualizações de solicitações e mensagens diretamente aqui no sistema.
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                Envio de e-mail é gerenciado pela instituição e não é configurável aqui.
               </div>
             </div>
           </div>
-          <label className="inline-flex cursor-pointer items-center">
-            <input
-              type="checkbox"
-              className="sr-only peer"
-              checked={emailNotif}
-              onChange={() => setEmailNotif((v) => !v)}
-            />
-            <div className="w-10 h-5 bg-[var(--muted)] rounded-full peer peer-checked:bg-primary transition-all relative">
-              <span className="absolute top-[2px] left-[2px] w-4 h-4 bg-background rounded-full transition-all peer-checked:translate-x-5" />
-            </div>
-          </label>
+          <Toggle checked={platNotif} onChange={() => setPlatNotif((v) => !v)} />
         </div>
 
-        {/* Limpar cache */}
+        {/* Restaurar preferências */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Trash2 className="size-5 text-muted-foreground" />
+            <RotateCcw className="size-5 text-muted-foreground" />
             <div>
-              <div className="font-medium">Limpar cache e sessões</div>
+              <div className="font-medium">Restaurar preferências padrão</div>
               <div className="text-sm text-muted-foreground">
-                Remove dados salvos localmente, como tokens e preferências.
+                Volta as configurações de tema e notificações para o padrão original.
               </div>
             </div>
           </div>
           <button
             type="button"
-            onClick={handleClearCache}
+            onClick={handleRestoreDefaults}
             className="inline-flex items-center gap-2 h-9 px-3 rounded-md border border-[var(--border)] bg-background hover:bg-[var(--muted)] text-sm"
           >
-            <Trash2 className="size-4" />
-            Limpar
+            <RotateCcw className="size-4" />
+            Restaurar
           </button>
         </div>
 
@@ -209,7 +183,7 @@ export default function ConfiguracoesAlunoPage() {
             type="submit"
             disabled={saving}
             className={cx(
-              "inline-flex items-center gap-2 h-10 px-4 rounded-lg bg-primary text-primary-foreground font-medium",
+              "inline-flex items-center gap-2 h-10 px-4 rounded-lg bg-primary text-primary-foreground font-medium text-sm",
               saving && "opacity-60 cursor-not-allowed"
             )}
           >

--- a/app/(dashboard)/aluno/notificacoes/page.tsx
+++ b/app/(dashboard)/aluno/notificacoes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { apiFetch } from "../../../../utils/api";
 import {
@@ -11,9 +11,12 @@ import {
   Paperclip,
   Check,
   Info,
+  AlertCircle,
 } from "lucide-react";
 import MobileSidebarTriggerAluno from "../_components/MobileSidebarTriggerAluno";
-import { cx } from '../../../../utils/cx'
+import { cx } from '../../../../utils/cx';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 /* ---------- Tipos ---------- */
 type Tipo =
@@ -44,7 +47,6 @@ type PageResp = {
   items: Notificacao[];
 };
 
-
 function TipoIcon({ tipo }: { tipo: Tipo }) {
   const cls = "size-4";
   switch (tipo) {
@@ -67,109 +69,102 @@ function TipoIcon({ tipo }: { tipo: Tipo }) {
 /* ---------- Página ---------- */
 export default function NotificacoesAlunoPage() {
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [notifs, setNotifs] = useState<Notificacao[]>([]);
   const [marking, setMarking] = useState<string | null>(null);
-  const [unread, setUnread] = useState(0); // Contador de notificações não lidas
-  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL;
+  const [markingAll, setMarkingAll] = useState(false);
 
-  // carregar notificações
+  const unread = notifs.filter((n) => !n.lidaEm).length;
+
   async function load() {
     setLoading(true);
+    setError(null);
     try {
-      const res = await apiFetch(`${apiBase}/notifications?orderDir=desc&page=1&pageSize=100`, {
-        cache: "no-store",
-      });
+      const res = await apiFetch(
+        `${API_BASE}/notifications?orderDir=desc&page=1&pageSize=100`,
+        { cache: "no-store" }
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error((err as any).error ?? `Erro ${res.status}`);
+      }
       const data: PageResp = await res.json();
       setNotifs(data.items ?? []);
-      setUnread(data.items.filter((n) => !n.lidaEm).length); // Recalcular as notificações não lidas
-    } catch {
+    } catch (e: any) {
+      setError(e?.message ?? "Não foi possível carregar as notificações");
       setNotifs([]);
-      setUnread(0); // Caso não haja notificações, garantir que o contador seja zero
     } finally {
       setLoading(false);
     }
   }
 
-  useEffect(() => {
-    load();
-  }, [apiBase]);
+  useEffect(() => { load(); }, []);
 
-  // Marcar notificação como lida
   async function markAsRead(id: string) {
+    setMarking(id);
     try {
-      setMarking(id);
-      await apiFetch(`${apiBase}/notifications/${id}/lida`, {
-        method: "PATCH",
-        body: JSON.stringify({ lida: true }),
-      });
-      setNotifs((xs) => xs.map((n) => (n.id === id ? { ...n, lidaEm: new Date().toISOString() } : n)));
-      setUnread((prevUnread) => prevUnread - 1); // Decrementar o contador de notificações não lidas
+      await apiFetch(`${API_BASE}/notifications/${id}/lida`, { method: "PATCH" });
+      setNotifs((xs) =>
+        xs.map((n) => (n.id === id ? { ...n, lidaEm: new Date().toISOString() } : n))
+      );
     } finally {
       setMarking(null);
     }
   }
 
-  // Marcar todas as notificações como lidas
   async function markAllAsRead() {
+    setMarkingAll(true);
     try {
-      setLoading(true);
-      // Enviar corpo com JSON
-await apiFetch(`${apiBase}/notifications/read-all`, {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json", // Especificar o tipo do conteúdo
-  },
-  body: JSON.stringify({ lida: true }), // Enviar corpo com a chave lida
-});
-
-
-      // Atualizar todas as notificações no estado como lidas
-      setNotifs((prevNotifs) =>
-        prevNotifs.map((n) => ({ ...n, lidaEm: new Date().toISOString() }))
+      await apiFetch(`${API_BASE}/notifications/read-all`, { method: "POST" });
+      setNotifs((prev) =>
+        prev.map((n) => ({ ...n, lidaEm: n.lidaEm ?? new Date().toISOString() }))
       );
-
-      // Resetando o contador de notificações não lidas
-      setUnread(0);
-    } catch (error) {
-      console.error("Erro ao marcar todas as notificações como lidas", error);
     } finally {
-      setLoading(false);
+      setMarkingAll(false);
     }
   }
 
   return (
     <div className="space-y-6">
-      {/* Topbar compacta */}
       <div className="mb-2 flex items-center justify-between">
         <MobileSidebarTriggerAluno />
       </div>
 
-      {/* Botão de "Marcar todas como lidas" */}
-      <div className="mb-4">
-        <button
-          onClick={markAllAsRead}
-          className="bg-[#D91F2B] text-white px-4 py-2 rounded hover:bg-[#B11D22]" // Vermelho mais escuro
-
-
-        >
-          Marcar todas como lidas
-        </button>
-      </div>
-
-      {/* Lista */}
       <div className="rounded-xl border border-[var(--border)] bg-card p-4 sm:p-5">
-        <div className="flex items-center gap-2 mb-4">
-          <Bell className="size-4 text-muted-foreground" />
-          <h2 className="text-base font-semibold">Novidades e alertas</h2>
+        <div className="flex items-center justify-between gap-2 mb-4">
+          <div className="flex items-center gap-2">
+            <Bell className="size-4 text-muted-foreground" />
+            <h2 className="text-base font-semibold">Novidades e alertas</h2>
+            {unread > 0 && (
+              <span className="rounded-md border border-[var(--border)] bg-background px-1.5 py-0.5 text-xs font-medium">
+                {unread} não lida{unread !== 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+          {notifs.length > 0 && unread > 0 && (
+            <button
+              onClick={markAllAsRead}
+              disabled={markingAll}
+              className="inline-flex items-center gap-2 h-8 px-3 rounded-md border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
+            >
+              {markingAll ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />}
+              Marcar todas como lidas
+            </button>
+          )}
         </div>
 
         {loading ? (
-          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <div className="flex items-center gap-2 text-muted-foreground text-sm py-8 justify-center">
             <Loader2 className="size-4 animate-spin" />
             Carregando notificações…
           </div>
+        ) : error ? (
+          <div className="flex items-center gap-2 text-sm text-destructive py-8 justify-center">
+            <AlertCircle className="size-4" />
+            {error}
+          </div>
         ) : notifs.length === 0 ? (
-          <div className="text-sm text-muted-foreground">
+          <div className="text-sm text-muted-foreground py-8 text-center">
             Nenhuma notificação no momento.
           </div>
         ) : (
@@ -179,7 +174,7 @@ await apiFetch(`${apiBase}/notifications/read-all`, {
                 key={n.id}
                 className={cx(
                   "p-3 sm:p-4 transition",
-                  !n.lidaEm ? "bg-[var(--brand-cyan)]/8" : "bg-card"
+                  !n.lidaEm ? "bg-[var(--brand-cyan)]/10" : ""
                 )}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -224,12 +219,15 @@ await apiFetch(`${apiBase}/notifications/read-all`, {
                     disabled={!!n.lidaEm || marking === n.id}
                     title="Marcar como lida"
                     className={cx(
-                      "shrink-0 inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md border text-[#4B5563] text-xs", // Cor de texto mais forte
-                      n.lidaEm ? "opacity-50 cursor-default border-[#6B7280]" : "border-[#D91F2B] text-[#D91F2B] hover:bg-[#D91F2B]/10"
+                      "shrink-0 inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md border text-xs transition",
+                      n.lidaEm
+                        ? "opacity-40 cursor-default border-[var(--border)] text-muted-foreground"
+                        : "border-[var(--border)] hover:bg-[var(--muted)] text-foreground"
                     )}
                   >
-
-                    {marking === n.id ? <Loader2 className="size-3.5 animate-spin" /> : <Check className="size-3.5" />}
+                    {marking === n.id
+                      ? <Loader2 className="size-3.5 animate-spin" />
+                      : <Check className="size-3.5" />}
                     Lida
                   </button>
                 </div>


### PR DESCRIPTION
## Resumo

- **Criação de chamado** — corrige erro 400 ao criar chamado via catálogo (campos do wizard não batem com a validação do backend)
- **Notificações** — corrige tratamento de erro, opacity inválida e cores hardcoded
- **Configurações do aluno** — corrige toggle quebrado, desabilita idioma, renomeia seção de e-mail e substitui "Limpar cache" por "Restaurar preferências"

## Detalhes

### Notificações (`aluno/notificacoes/page.tsx`)
- Adiciona verificação de `res.ok` antes de parsear JSON — erros agora são exibidos na tela ao invés de silenciosos
- Corrige `apiBase` sem `?? ""` que gerava URL `undefined/notifications`
- Remove import `useMemo` não utilizado
- Corrige opacity `/8` → `/10` (Tailwind não gera a classe `/8` por padrão)
- Botões padronizados com variáveis CSS do tema (sem cores hardcoded)
- "Marcar todas como lidas" só aparece quando há notificações não lidas

### Configurações (`aluno/configuracoes/page.tsx`)
- **Toggle CSS corrigido**: `peer-checked:translate-x-5` em neto do `peer` não funciona em Tailwind; substituído por componente `<Toggle>` que usa estado JS para controlar posição do knob
- **Idioma**: campo desabilitado com badge "em breve" e descrição honesta ("sistema disponível apenas em Português")
- **Notificações por e-mail** → renomeado para **"Notificações na plataforma"** com nota de que e-mail é gerenciado pela instituição e não configurável aqui
- **"Limpar cache e sessões"** → substituído por **"Restaurar preferências padrão"** — mesma funcionalidade (reset de tema/notif para o padrão), sem implicar limpeza de sessão/tokens para o usuário final

## Checklist de testes

- [ ] Abrir catálogo como aluno e criar chamado de qualquer categoria — não deve retornar erro 400
- [ ] Acessar `/aluno/notificacoes` — lista carrega ou exibe mensagem de erro clara
- [ ] Clicar em "Marcar como lida" em uma notificação — item atualiza sem recarregar
- [ ] Acessar `/aluno/configuracoes` — toggle de tema muda o knob visualmente (claro ↔ escuro)
- [ ] Campo de idioma aparece desabilitado com badge "em breve"
- [ ] Botão "Restaurar" reseta tema e notificações para o padrão

https://claude.ai/code/session_013c4rkTAfZV3ccHN45kea98

---
_Generated by [Claude Code](https://claude.ai/code/session_013c4rkTAfZV3ccHN45kea98)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capability to edit student records via dedicated modal interface
  * Introduced dynamic ticket statistics display in admin dashboard
  * Converted reports page to real-time API data instead of mock data

* **Improvements**
  * Enhanced student creation form with expanded academic fields (unit, shift, class, semester)
  * Improved CSV import with better field parsing and support for additional academic information
  * Streamlined student notification management with direct mark-all-as-read action
  * Simplified student settings to focus on theme preference and notification toggles
  * Updated student detail page with additional information cards and improved layout

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FATEC-Projeto/frontend/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->