### PR TITLE
fix: corrige redirecionamento após login em ambiente HTTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ FROM base AS builder
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# NEXT_PUBLIC_* precisam estar disponíveis em BUILD TIME para serem
+# embutidas no bundle pelo Next.js. Passe via --build-arg no docker build.
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
+
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
@@ -37,4 +42,6 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
+# Variáveis server-side (JWT_ACCESS_SECRET, JWT_ISSUER, etc.) são lidas
+# em runtime — basta passá-las no docker run -e ou no docker-compose.yml.
 CMD ["node", "server.js"]

--- a/app/(public)/login/LoginContent.tsx
+++ b/app/(public)/login/LoginContent.tsx
@@ -77,8 +77,10 @@ export default function LoginContent() {
 
   function storeAuthTokens(data: Record<string, unknown>) {
     if (!data?.accessToken) return;
-    const isProd = process.env.NODE_ENV === "production";
-    const secure = isProd ? "; Secure" : "";
+    // Usa o protocolo real da página — cookie Secure só funciona em HTTPS.
+    // NODE_ENV=production não garante HTTPS (ex: IP direto na AWS).
+    const isSecure = window.location.protocol === "https:";
+    const secure = isSecure ? "; Secure" : "";
     document.cookie = `accessToken=${data.accessToken}; Path=/; Max-Age=${15 * 60}; SameSite=Lax${secure}`;
     localStorage.setItem("accessToken", String(data.accessToken));
     if (data.refreshToken) {

--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+
+function mask(value: string | undefined): string {
+  if (!value) return '(não definida)'
+  if (value.length <= 6) return '***'
+  return value.slice(0, 3) + '***' + value.slice(-3)
+}
+
+export async function GET() {
+  return NextResponse.json({
+    server: {
+      JWT_ACCESS_SECRET:  mask(process.env.JWT_ACCESS_SECRET),
+      JWT_ISSUER:         process.env.JWT_ISSUER         ?? '(não definida)',
+      JWT_AUDIENCE:       process.env.JWT_AUDIENCE       ?? '(não definida)',
+      NODE_ENV:           process.env.NODE_ENV           ?? '(não definida)',
+    },
+    buildtime: {
+      NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL ?? '(não definida — baked in vazia no build!)',
+    },
+  })
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,14 +8,13 @@ const ADMIN_HOME = '/admin/home'
 const ALUNO_HOME = '/aluno/home'
 const LOGIN_PATH = '/login'
 
-const AUTH_PAGES = ['/login', '/primeiro-acesso', '/recuperar-senha']
+const AUTH_PAGES = ['/login', '/primeiro-acesso', '/esqueci-senha', '/reset-senha']
 const protectedPrefixes = ['/admin', '/aluno']
 
 async function getJwtPayload(token: string) {
   try {
     if (!process.env.JWT_ACCESS_SECRET) return null
     const secret = new TextEncoder().encode(process.env.JWT_ACCESS_SECRET)
-    if (!process.env.JWT_ACCESS_SECRET) return null
     const { payload } = await jwtVerify(token, secret, {
       issuer: process.env.JWT_ISSUER || 'helpdesk',
       audience: process.env.JWT_AUDIENCE || 'helpdesk-app',


### PR DESCRIPTION
## Problema

O site está rodando em HTTP (`http://34.228.231.101`), mas os cookies eram marcados com flag `Secure` baseado em `NODE_ENV=production`. O browser descarta silenciosamente cookies `Secure` em HTTP — por isso o login parecia funcionar (toast verde aparecia) mas o usuário voltava para o login imediatamente.

## O que foi corrigido

**`LoginContent.tsx`** — cookie `Secure` agora baseado no protocolo real da página, não em `NODE_ENV`:
```diff
- const isProd = process.env.NODE_ENV === "production";
- const secure = isProd ? "; Secure" : "";
+ const isSecure = window.location.protocol === "https:";
+ const secure = isSecure ? "; Secure" : "";
```

**`middleware.ts`** — `AUTH_PAGES` corrigido com as rotas reais:
```diff
- const AUTH_PAGES = ['/login', '/primeiro-acesso', '/recuperar-senha']
+ const AUTH_PAGES = ['/login', '/primeiro-acesso', '/esqueci-senha', '/reset-senha']
```

**`Dockerfile`** — `NEXT_PUBLIC_API_BASE_URL` agora recebida via `--build-arg` (variáveis `NEXT_PUBLIC_*` precisam estar disponíveis em build time no Next.js).

**`app/api/debug-env/route.ts`** — rota temporária para diagnóstico de variáveis de ambiente.

## Como usar após o merge

Rebuildar a imagem passando a URL do backend:
```bash
docker build \
  --build-arg NEXT_PUBLIC_API_BASE_URL=http://34.228.231.101:<porta-do-backend> \
  -t frontend .
```

> Quando o site tiver HTTPS, o comportamento do cookie voltará a ser seguro automaticamente.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2otSfnMg4CCbUD1GPX83Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Cookies de autenticação agora utilizam corretamente a detecção do protocolo HTTPS para aplicar a flag de segurança, melhorando a proteção em conexões seguras.

* **New Features**
  * Nova rota de reset de senha adicionada ao fluxo de autenticação.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FATEC-Projeto/frontend/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->