### PR TITLE
Fix loading state handling in ticket detail page fetch functions

### DIFF
--- a/app/(dashboard)/aluno/chamados/[id]/page.tsx
+++ b/app/(dashboard)/aluno/chamados/[id]/page.tsx
@@ -18,7 +18,7 @@ import type { Chamado, Status } from "../../../../../utils/types";
 
 /* ================= Constantes ================= */
 
-const API = process.env.NEXT_PUBLIC_API_BASE_URL;
+const API = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = new Set([
@@ -131,7 +131,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Chamado ===== */
   const fetchChamado = useCallback(async () => {
-    if (!API || !id) return;
+    if (!API || !id) { setLoading(false); return; }
     setLoading(true);
     try {
       const res = await apiFetch(`${API}/tickets/${id}`);
@@ -148,7 +148,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Mensagens ===== */
   const fetchMensagens = useCallback(async () => {
-    if (!API || !id) return;
+    if (!API || !id) { setMsgLoading(false); return; }
     setMsgLoading(true);
     try {
       const res = await apiFetch(
@@ -241,7 +241,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Anexos ===== */
   const fetchAnexos = useCallback(async () => {
-    if (!API || !id) return;
+    if (!API || !id) { setLoadingAnexos(false); return; }
     setLoadingAnexos(true);
     try {
       const res = await apiFetch(`${API}/tickets/${id}/anexos`);


### PR DESCRIPTION
## Summary
Fixed loading state management in the ticket detail page to ensure loading states are properly reset when API configuration or route parameters are missing, preventing UI from getting stuck in loading state.

## Key Changes
- Added nullish coalescing operator (`??`) to API constant initialization to provide a default empty string fallback
- Updated `fetchChamado()` to set `setLoading(false)` before returning when API or ID is missing
- Updated `fetchMensagens()` to set `setMsgLoading(false)` before returning when API or ID is missing
- Updated `fetchAnexos()` to set `setLoadingAnexos(false)` before returning when API or ID is missing

## Implementation Details
These changes prevent the loading spinners from remaining visible indefinitely when the component mounts without the necessary API configuration or route ID. Previously, the early returns would skip the loading state reset, leaving the UI in a loading state. Now, each fetch function properly cleans up its loading state before exiting early.

https://claude.ai/code/session_01Pt3GwTcPGoqhoLQ7hsXUt7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorado o tratamento de casos onde a configuração da API está ausente, garantindo que os estados de carregamento sejam devidamente atualizados e a aplicação se comporte de forma mais confiável em cenários de configuração incompleta.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FATEC-Projeto/frontend/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->