### PR TITLE
fix: proxy API via Next.js rewrites para corrigir 404 em /aluno/notificacoes

### DIFF
--- a/app/(dashboard)/aluno/chamados/[id]/page.tsx
+++ b/app/(dashboard)/aluno/chamados/[id]/page.tsx
@@ -18,7 +18,7 @@ import type { Chamado, Status } from "../../../../../utils/types";
 
 /* ================= Constantes ================= */
 
-const API = process.env.NEXT_PUBLIC_API_BASE_URL;
+const API = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = new Set([
@@ -131,7 +131,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Chamado ===== */
   const fetchChamado = useCallback(async () => {
-    if (!API || !id) return;
+    if (!API || !id) { setLoading(false); return; }
     setLoading(true);
     try {
       const res = await apiFetch(`${API}/tickets/${id}`);
@@ -148,7 +148,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Mensagens ===== */
   const fetchMensagens = useCallback(async () => {
-    if (!API || !id) return;
+    if (!API || !id) { setMsgLoading(false); return; }
     setMsgLoading(true);
     try {
       const res = await apiFetch(
@@ -241,7 +241,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Anexos ===== */
   const fetchAnexos = useCallback(async () => {
-    if (!API || !id) return;
+    if (!API || !id) { setLoadingAnexos(false); return; }
     setLoadingAnexos(true);
     try {
       const res = await apiFetch(`${API}/tickets/${id}/anexos`);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,19 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
 
+  // Proxy API calls to backend when NEXT_PUBLIC_API_BASE_URL is not set at build time.
+  // BACKEND_URL is read at runtime, so set it in the container environment.
+  async rewrites() {
+    const backend = process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!backend) return [];
+    return [
+      {
+        source: "/:path*",
+        destination: `${backend}/:path*`,
+      },
+    ];
+  },
+
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

- Adiciona `async rewrites()` no `next.config.mjs` para proxiar chamadas de API ao backend quando `NEXT_PUBLIC_API_BASE_URL` não está definida em build time

## Causa raiz

Quando `NEXT_PUBLIC_API_BASE_URL` não é passada como `--build-arg` no `docker build`, o bundle do Next.js usa `""` como base. As chamadas de API viram URLs relativas (ex: `/notifications?...`) e caem no nginx/Next.js — que não sabe rotear `/notifications` para o backend Fastify — retornando HTML 404. O frontend falha ao parsear HTML como JSON e exibe `"Erro 404"`.

## Fix

Com a variável de ambiente `BACKEND_URL` definida no container em runtime (ex: `BACKEND_URL=http://backend:3333`), o Next.js passa a proxiar automaticamente todas as rotas que não casam com páginas existentes (como `/notifications`, `/auth`, `/tickets`, etc.) para o backend.

Se `NEXT_PUBLIC_API_BASE_URL` estiver definida em build time (chamadas diretas ao backend), o rewrite não interfere.

## Como ativar no servidor

Definir no container do frontend:
```
BACKEND_URL=http://<url-do-backend>:<porta>
```

https://claude.ai/code/session_01Pt3GwTcPGoqhoLQ7hsXUt7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pt3GwTcPGoqhoLQ7hsXUt7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorado o tratamento de inicialização da API quando variáveis de ambiente estão ausentes, evitando valores indefinidos.
  * Estados de carregamento agora atualizam corretamente quando a URL da API ou identificadores necessários não estão disponíveis.
  * Adicionado suporte a configuração alternativa de backend como fallback quando a variável padrão não está definida.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FATEC-Projeto/frontend/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->