### PR TITLE
fix: use GET /usuarios for admin student list (wrong endpoint)

### DIFF
--- a/app/(dashboard)/admin/alunos/page.tsx
+++ b/app/(dashboard)/admin/alunos/page.tsx
@@ -45,7 +45,6 @@ type AlunoRow = {
 
 /* ========= ENV ========= */
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
-const USERS_PATH = process.env.NEXT_PUBLIC_USERS_PATH ?? "/auth/usuarios";
 const ALUNO_DETAIL_PREFIX = "/admin/alunos/";
 
 function StatusBadge({ status }: { status: StatusAtivo }) {
@@ -96,24 +95,20 @@ export default function AdminAlunosPage() {
 
       const qs = new URLSearchParams();
       qs.set("papel", "USUARIO");
-      if (q) qs.set("search", q);
+      if (q) qs.set("q", q);
       if (status !== "ALL") qs.set("ativo", String(status === "ATIVO"));
       qs.set("page", String(page));
       qs.set("perPage", String(perPage));
 
-      let res = await fetch(`${API_URL}${USERS_PATH}?${qs}`, { headers, cache: "no-store" });
+      const res = await fetch(`${API_URL}/usuarios?${qs}`, { headers, cache: "no-store" });
       if (!res.ok) {
-        const fallback = USERS_PATH === "/usuarios" ? "/auth/usuarios" : "/usuarios";
-        const res2 = await fetch(`${API_URL}${fallback}?${qs}`, { headers, cache: "no-store" });
-        if (!res2.ok) {
-          const text = await res2.text().catch(() => "");
-          throw new Error(text || `Falha ao buscar alunos (${res2.status})`);
-        }
-        res = res2;
+        const text = await res.text().catch(() => "");
+        throw new Error(text || `Falha ao buscar alunos (${res.status})`);
       }
 
       const json = await res.json();
-      const usuarios: Usuario[] = Array.isArray(json) ? json : json.data ?? [];
+      // GET /usuarios retorna { items, page, perPage, total, pages }
+      const usuarios: Usuario[] = Array.isArray(json) ? json : (json.items ?? json.data ?? []);
       const alunosApenas = usuarios.filter((u) => (u.papel ?? "USUARIO") === "USUARIO");
 
       const mapped: AlunoRow[] = alunosApenas.map((u) => ({


### PR DESCRIPTION
## Problema

A página `/admin/alunos` chamava `GET /auth/usuarios` para listar alunos, mas esse endpoint é de **busca individual** (aceita `ra`, `email`, `id` — retorna no máximo 1 usuário). Os filtros enviados pelo frontend eram todos ignorados:

| Parâmetro enviado | Suportado em `/auth/usuarios` |
|---|---|
| `papel=USUARIO` | ❌ |
| `search=...` | ❌ |
| `ativo=true/false` | ❌ |
| `page`, `perPage` | ❌ |

O endpoint correto é `GET /usuarios` que suporta todos esses filtros com paginação.

## Correção

Três bugs corrigidos juntos (mesmo arquivo):

1. **Endpoint**: `/auth/usuarios` → `/usuarios`
2. **Parâmetro de busca**: `search` → `q` (conforme `UserListSchema`)
3. **Formato da resposta**: `json.data` → `json.items` (envelope paginado: `{ items, page, perPage, total, pages }`)

## Arquivo alterado

- `app/(dashboard)/admin/alunos/page.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc73jg3jvnH7xFe2PqD8Qu)_