### PR TITLE
fix: merge API catalog with static keywords for OUTROS keyword matching

### DIFF
--- a/app/(dashboard)/aluno/catalogo/outros/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/outros/page.tsx
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 import { apiFetch } from "../../../../../utils/api";
 import {
   CATALOGO_INSTITUCIONAL,
+  enriquecerCatalogo,
   type CatalogResponse,
   type ServicoCatalogo,
 } from "../../../../../utils/catalogo";
@@ -117,7 +118,7 @@ export default function OutrosPage() {
     apiFetch(`${API}/catalogo`, { cache: "no-store" })
       .then((r) => r.ok ? r.json() : null)
       .then((data: CatalogResponse | null) => {
-        if (data?.categorias) setCatalog(data);
+        if (data?.categorias) setCatalog(enriquecerCatalogo(data));
       })
       .catch(() => {});
 

--- a/app/(dashboard)/aluno/catalogo/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Search, Layers, BookOpen, Plus, Loader2, ArrowRight, HelpCircle } from "lucide-react";
 import MobileSidebarTriggerAluno from "../_components/MobileSidebarTriggerAluno";
-import { CATALOGO_INSTITUCIONAL, type CatalogResponse, type ServicoCatalogo } from "../../../../utils/catalogo";
+import { CATALOGO_INSTITUCIONAL, enriquecerCatalogo, type CatalogResponse, type ServicoCatalogo } from "../../../../utils/catalogo";
 import { cx } from "../../../../utils/cx";
 import { apiFetch } from "../../../../utils/api";
 
@@ -80,9 +80,9 @@ export default function CatalogoAlunoPage() {
         const res = await apiFetch(url, { cache: "no-store" });
         if (!res.ok) throw new Error("fallback");
         const data = (await res.json()) as CatalogResponse;
-        setCatalog({
+        setCatalog(enriquecerCatalogo({
           categorias: (data.categorias ?? []).map((c) => ({ ...c, servicos: c.servicos ?? [] })),
-        });
+        }));
       } catch {
         setCatalog(MOCK);
       } finally {

--- a/utils/catalogo.ts
+++ b/utils/catalogo.ts
@@ -70,6 +70,42 @@ function servico(
   };
 }
 
+/**
+ * Merges a raw API catalog response (which lacks palavrasChave and formulario)
+ * with the enriched mock, using IDs to match categories and services.
+ * Falls back to empty arrays/FORMULARIO_FUTURO when no match is found.
+ */
+export function enriquecerCatalogo(apiData: CatalogResponse): CatalogResponse {
+  const mockCatById = new Map(
+    CATALOGO_INSTITUCIONAL.categorias.map((c) => [c.id, c]),
+  );
+
+  return {
+    categorias: apiData.categorias.map((cat) => {
+      const mockCat = mockCatById.get(cat.id);
+      const mockSvcById = new Map(
+        (mockCat?.servicos ?? []).map((s) => [s.id, s]),
+      );
+      return {
+        ...cat,
+        palavrasChave: cat.palavrasChave?.length
+          ? cat.palavrasChave
+          : (mockCat?.palavrasChave ?? []),
+        servicos: cat.servicos.map((svc) => {
+          const mockSvc = mockSvcById.get(svc.id);
+          return {
+            ...svc,
+            palavrasChave: (svc as any).palavrasChave?.length
+              ? (svc as any).palavrasChave
+              : (mockSvc?.palavrasChave ?? []),
+            formulario: (svc as any).formulario ?? mockSvc?.formulario ?? FORMULARIO_FUTURO,
+          };
+        }),
+      };
+    }),
+  };
+}
+
 export const CATALOGO_INSTITUCIONAL: CatalogResponse = {
   categorias: [
     {


### PR DESCRIPTION
## Problema

O modelo `Servico` no Prisma não possui os campos `palavrasChave` nem `formulario`. Quando o frontend carrega o catálogo via API, esses campos estão ausentes na resposta, fazendo o matching de palavras-chave do fluxo **OUTROS** funcionar apenas sobre `nome` e `descricao` — ignorando as listas de keywords curadas no mock estático.

Exemplo: um aluno escrevendo "declaração" não encontraria "Declaração de matrícula" se a busca dependesse de `palavrasChave` do banco, pois o campo retorna vazio.

## Solução

Adicionada a função `enriquecerCatalogo()` em `utils/catalogo.ts` que:

- Recebe a resposta bruta da API
- Para cada categoria e serviço, faz lookup pelo `id` no `CATALOGO_INSTITUCIONAL`
- Injeta `palavrasChave` e `formulario` do mock onde a API não retorna esses campos
- Preserva dados da API se o campo já vier preenchido (forward-compatible)

Aplicada nos `useEffect` de carregamento em `CatalogoAlunoPage` e `OutrosPage`.

## Arquivos alterados

- `utils/catalogo.ts` — nova função `enriquecerCatalogo()`
- `app/(dashboard)/aluno/catalogo/page.tsx` — usa `enriquecerCatalogo` ao carregar
- `app/(dashboard)/aluno/catalogo/outros/page.tsx` — usa `enriquecerCatalogo` ao carregar

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc73jg3jvnH7xFe2PqD8Qu)_