### PR TITLE
fix: send senha instead of senhaInicial in student create payload

### DIFF
--- a/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
+++ b/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
@@ -118,7 +118,7 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
       };
 
       if (usarSenhaPersonalizada && senhaInicial.trim()) {
-        payload.senhaInicial = senhaInicial.trim();
+        payload.senha = senhaInicial.trim();
       }
 
       if (cursoNome.trim())           payload.cursoNome           = cursoNome.trim();


### PR DESCRIPTION
## Contexto

Corrige o payload do `FormAlunoCreate` para usar o campo `senha` em vez de `senhaInicial`.

O backend foi refatorado para usar `d.senha ?? DEFAULT_TEMP_PASSWORD` para todos os usuários (staff e alunos), eliminando o campo `senhaInicial`. O formulário precisava ser atualizado para enviar o campo correto.

## Alteração

`payload.senhaInicial` → `payload.senha` (1 linha em `FormAlunoCreate.tsx`)

## Dependência

Deve ser mergeado junto ou após o PR backend [#74](https://github.com/FATEC-Projeto/backend/pull/74).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc73jg3jvnH7xFe2PqD8Qu)_