### PR TITLE
feat: dados acadêmicos, downloads autenticados, fluxo OUTROS, redesign senha aluno e correções de auditoria

### DIFF
--- a/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
+++ b/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
@@ -68,6 +68,7 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
 
   const [submitting, setSubmitting] = useState(false);
   const [successInfo, setSuccessInfo] = useState<SuccessInfo | null>(null);
+  const [lastCreated, setLastCreated] = useState<any>(null);
   const [copied, setCopied] = useState(false);
 
   function handleCourseChange(val: string) {
@@ -99,7 +100,7 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
     setUnidadeFatec(""); setTurno(""); setTurma("");
     setSemestreAtual(""); setAnoSemestreIngresso("");
     setUsarSenhaPersonalizada(false); setSenhaInicial(""); setMostrarSenha(false);
-    setSuccessInfo(null); setCopied(false);
+    setSuccessInfo(null); setLastCreated(null); setCopied(false);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -150,14 +151,13 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
 
       const created = await res.json();
 
+      setLastCreated(created);
       setSuccessInfo({
         nome: nome.trim() || created?.nome || "",
         ra: ra.trim(),
         email: emailEducacional,
         senhaUsada: usarSenhaPersonalizada && senhaInicial.trim() ? senhaInicial.trim() : null,
       });
-
-      onSuccess?.(created);
     } catch (err: any) {
       console.error(err);
       toast.error(err?.message ?? "Erro ao criar aluno");
@@ -226,10 +226,10 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
           >
             <RotateCcw className="size-3.5" /> Cadastrar outro
           </button>
-          {onCancel && (
+          {(onSuccess || onCancel) && (
             <button
               type="button"
-              onClick={onCancel}
+              onClick={() => onSuccess ? onSuccess(lastCreated) : onCancel?.()}
               className="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-sm hover:brightness-95"
             >
               Concluído


### PR DESCRIPTION
## Resumo

Três commits com melhorias e correções de alinhamento frontend/backend identificadas na auditoria:

### 1. Dados acadêmicos, downloads autenticados, sino e fluxo OUTROS
- **Dados acadêmicos** — admin/chamado busca perfil completo via `GET /usuarios/:id`; aluno/chamado mostra painel com RA, unidade, curso, turno, turma, semestre via `/auth/me`
- **Downloads autenticados** — `downloadAnexo()` e `fetchAnexoImageUrl()` em `utils/api.ts` fazem fetch com JWT; substituem `<a href>` direto que não enviava o token
- **Sino de notificações** — fica vermelho com borda realçada quando há itens não lidos; tooltip mostra contagem
- **Catálogo OUTROS** — fluxo multi-etapa: descrever → sugestões por palavras-chave → formulário → sucesso; card especial "Não encontrei o que preciso" em modo listagem

### 2. Redesign do formulário de cadastro de aluno (senha)
- Substitui `alert()` por `toast.error()` para feedback de erros
- Toggle "Definir senha personalizada" com campo show/hide
- Card de sucesso após criação com RA, e-mail e senha (com botão de cópia)
- Atalho "Cadastrar outro" para resetar o formulário
- Payload corrigido: envia campo `senha` (não `senhaInicial`)

### 3. Correções de alinhamento (auditoria)
- **Listagem de alunos** — trocado `GET /auth/usuarios` por `GET /usuarios` (paginado), parâmetro `search` → `q`, shape `json.data` → `json.items`
- **Palavras-chave do catálogo** — `enriquecerCatalogo()` em `utils/catalogo.ts` mescla dados da API com mock estático via ID, garantindo que matching de keywords funcione com dados reais (o schema DB não persiste `palavrasChave`/`formulario`)

## Plano de testes

- [ ] Login e redirecionamento por papel (aluno / admin)
- [ ] Fluxo completo de abertura de chamado via catálogo, incluindo categoria OUTROS
- [ ] Download de anexo autenticado (verificar que o token JWT é enviado)
- [ ] Cadastro de aluno com senha personalizada e com senha padrão do sistema
- [ ] Listagem de alunos no admin com filtro e busca por texto
- [ ] Badge de notificações atualiza em tempo real

https://claude.ai/code/session_01Xc73jg3jvnH7xFe2PqD8Qu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc73jg3jvnH7xFe2PqD8Qu)_