### PR TITLE
fix: logout silencioso no refresh em HTTP + fetches pulados no modo proxy

### DIFF
--- a/app/(dashboard)/admin/chamados/[id]/page.tsx
+++ b/app/(dashboard)/admin/chamados/[id]/page.tsx
@@ -211,7 +211,7 @@ export default function AdminChamadoPage() {
 
   /* ===== Perfil acadêmico do aluno (banco de dados) ===== */
   useEffect(() => {
-    if (!ticket?.criadoPorId || !API) return;
+    if (!ticket?.criadoPorId) return;
     apiFetch(`${API}/usuarios/${ticket.criadoPorId}`, { cache: "no-store" })
       .then((r) => r.ok ? r.json() : null)
       .then((data: PerfilAcademico | null) => { if (data) setPerfilAluno(data); })
@@ -224,7 +224,7 @@ export default function AdminChamadoPage() {
 
   // WebSocket em tempo real — token lido dentro de connect() para ficar fresco
   useEffect(() => {
-    if (!id || !API) return;
+    if (!id) return;
 
     let ws: WebSocket | null = null;
     let attempt = 0;
@@ -233,7 +233,7 @@ export default function AdminChamadoPage() {
     function connect() {
       const token = typeof window !== "undefined" ? (localStorage.getItem("accessToken") ?? "") : "";
       if (!token) return;
-      const wsUrl = API.replace(/^http/, "ws") + `/ws?token=${encodeURIComponent(token)}`;
+      const wsUrl = (API || window.location.origin).replace(/^http/, "ws") + `/ws?token=${encodeURIComponent(token)}`;
       ws = new WebSocket(wsUrl);
 
       ws.onopen = () => {

--- a/app/(dashboard)/aluno/catalogo/[servicoId]/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/[servicoId]/page.tsx
@@ -228,7 +228,6 @@ export default function SolicitacaoCatalogoPage() {
   }, []);
 
   useEffect(() => {
-    if (!API) return;
     apiFetch(`${API}/auth/me`, { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
@@ -294,7 +293,7 @@ export default function SolicitacaoCatalogoPage() {
   function removeFile(index: number) { setAnexos((prev) => prev.filter((_, i) => i !== index)); }
 
   async function uploadAnexos(ticketId: string | number) {
-    if (!API || anexos.length === 0) return;
+    if (anexos.length === 0) return;
     for (const file of anexos) {
       const formData = new FormData();
       formData.append("file", file);

--- a/app/(dashboard)/aluno/catalogo/outros/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/outros/page.tsx
@@ -114,7 +114,6 @@ export default function OutrosPage() {
 
   /* Busca catálogo e dados acadêmicos do aluno */
   useEffect(() => {
-    if (!API) return;
     apiFetch(`${API}/catalogo`, { cache: "no-store" })
       .then((r) => r.ok ? r.json() : null)
       .then((data: CatalogResponse | null) => {

--- a/app/(dashboard)/aluno/chamados/[id]/page.tsx
+++ b/app/(dashboard)/aluno/chamados/[id]/page.tsx
@@ -166,7 +166,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Chamado ===== */
   const fetchChamado = useCallback(async () => {
-    if (!API || !id) { setLoading(false); return; }
+    if (!id) { setLoading(false); return; }
     setLoading(true);
     try {
       const res = await apiFetch(`${API}/tickets/${id}`);
@@ -183,7 +183,6 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Dados acadêmicos básicos do aluno ===== */
   useEffect(() => {
-    if (!API) return;
     apiFetch(`${API}/auth/me`, { cache: "no-store" })
       .then((r) => r.ok ? r.json() : null)
       .then((data: DadosAcademicosUser | null) => {
@@ -194,7 +193,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Mensagens ===== */
   const fetchMensagens = useCallback(async () => {
-    if (!API || !id) { setMsgLoading(false); return; }
+    if (!id) { setMsgLoading(false); return; }
     setMsgLoading(true);
     try {
       const res = await apiFetch(
@@ -217,8 +216,10 @@ export default function ChamadoDetalhePage() {
 
   /* ===== WebSocket — JWT via ?token= + exponential backoff ===== */
   useEffect(() => {
-    if (!API || !id) return;
-    const wsBase = API.replace(/^http/, "ws");
+    if (!id) return;
+    // Com API vazio (modo proxy), conecta na mesma origem — funciona quando o
+    // reverse proxy encaminha /ws; o backoff cobre o caso de não encaminhar.
+    const wsBase = (API || window.location.origin).replace(/^http/, "ws");
 
     let ws: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -263,7 +264,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Enviar Mensagem ===== */
   const sendMensagem = useCallback(async () => {
-    if (!msgText.trim() || !chamado?.id || !API) return;
+    if (!msgText.trim() || !chamado?.id) return;
     setMsgSending(true);
     try {
       const res = await apiFetch(`${API}/tickets/${chamado.id}/mensagens`, {
@@ -287,7 +288,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Fetch Anexos ===== */
   const fetchAnexos = useCallback(async () => {
-    if (!API || !id) { setLoadingAnexos(false); return; }
+    if (!id) { setLoadingAnexos(false); return; }
     setLoadingAnexos(true);
     try {
       const res = await apiFetch(`${API}/tickets/${id}/anexos`);
@@ -305,7 +306,7 @@ export default function ChamadoDetalhePage() {
 
   /* ===== Upload via apiFetch + validação ===== */
   const handleUpload = useCallback(async () => {
-    if (!selectedFile || !chamado?.id || !API) return;
+    if (!selectedFile || !chamado?.id) return;
     if (selectedFile.size > MAX_FILE_SIZE_BYTES) {
       toast.error("Arquivo muito grande. Máximo permitido: 10 MB.");
       return;
@@ -337,7 +338,7 @@ export default function ChamadoDetalhePage() {
   /* ===== Alterar status ===== */
   const atualizarStatus = useCallback(
     async (novoStatus: Status): Promise<boolean> => {
-      if (!chamado?.id || !API) return false;
+      if (!chamado?.id) return false;
       try {
         const res = await apiFetch(`${API}/tickets/${chamado.id}`, {
           method: "PATCH",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      i:
-        specifier: ^0.3.7
-        version: 0.3.7
       jose:
         specifier: 6.1.0
         version: 6.1.0
@@ -172,89 +169,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -325,24 +338,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.4':
     resolution: {integrity: sha512-TOK7iTxmXFc45UrtKqWdZ1shfxuL4tnVAOuuJK4S88rX3oyVV4ZkLjtMT85wQkfBrOOvU55aLty+MV8xmcJR8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.4':
     resolution: {integrity: sha512-7HKolaj+481FSW/5lL0BcTkA4Ueam9SPYWyN/ib/WGAFZf0DGAN8frNpNZYFHtM4ZstrHZS3LY3vrwlIQfsiMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.4':
     resolution: {integrity: sha512-nlQQ6nfgN0nCO/KuyEUwwOdwQIGjOs4WNMjEUtpIQJPR2NUfmGpW2wkJln1d4nJ7oUzd1g4GivH5GoEPBgfsdw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.4':
     resolution: {integrity: sha512-PcR2bN7FlM32XM6eumklmyWLLbu2vs+D7nJX8OAIoWy69Kef8mfiN4e8TUv2KohprwifdpFKPzIP1njuCjD0YA==}
@@ -419,24 +436,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.14':
     resolution: {integrity: sha512-ISZjT44s59O8xKsPEIesiIydMG/sCXoMBCqsphDm/WcbnuWLxxb+GcvSIIA5NjUw6F8Tex7s5/LM2yDy8RqYBQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.14':
     resolution: {integrity: sha512-02c6JhLPJj10L2caH4U0zF8Hji4dOeahmuMl23stk0MU1wfd1OraE7rOloidSF8W5JTHkFdVo/O7uRUJJnUAJg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.14':
     resolution: {integrity: sha512-TNGeLiN1XS66kQhxHG/7wMeQDOoL0S33x9BgmydbrWAb9Qw0KYdd8o1ifx4HOGDWhVmJ+Ul+JQ7lyknQFilO3Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.14':
     resolution: {integrity: sha512-uZYAsaW/jS/IYkd6EWPJKW/NlPNSkWkBlaeVBi/WsFQNP05/bzkebUL8FH1pdsqx4f2fH/bWFcUABOM9nfiJkQ==}
@@ -593,41 +614,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1200,10 +1229,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  i@0.3.7:
-    resolution: {integrity: sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==}
-    engines: {node: '>=0.4'}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1423,24 +1448,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -3263,8 +3292,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  i@0.3.7: {}
 
   ignore@5.3.2: {}
 

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -28,8 +28,10 @@ async function tryRefreshToken(): Promise<string | null> {
       const data = await res.json();
       if (!data?.accessToken) return null;
 
-      const isProd = process.env.NODE_ENV === "production";
-      const secure = isProd ? "; Secure" : "";
+      // Usa o protocolo real da página — cookie Secure só funciona em HTTPS.
+      // NODE_ENV=production não garante HTTPS (ex: IP direto na AWS).
+      const isSecure = typeof window !== "undefined" && window.location.protocol === "https:";
+      const secure = isSecure ? "; Secure" : "";
 
       document.cookie = `accessToken=${data.accessToken}; Path=/; Max-Age=${15 * 60}; SameSite=Lax${secure}`;
       localStorage.setItem("accessToken", data.accessToken);


### PR DESCRIPTION
## Resumo

Correções encontradas na validação dos últimos ajustes do frontend.

### 🔴 Críticos
- **`utils/api.ts`**: `tryRefreshToken` ainda decidia o atributo `Secure` do cookie por `NODE_ENV=production`; em produção via HTTP o browser descartava o cookie renovado e o usuário era deslogado silenciosamente após 15 min. Passa a usar `window.location.protocol`, igual ao fix do login (#92).
- **Guards `if (!API)`**: no modo proxy via rewrites (#94), com `NEXT_PUBLIC_API_BASE_URL` vazio, os guards impediam qualquer fetch e as telas ficavam vazias sem nenhum erro. Removidos das páginas de detalhe de chamado (aluno e admin) e do catálogo do aluno — com `API` vazio as URLs relativas passam pelo rewrite normalmente. O WebSocket cai para a origem da página quando `API` está vazio (funciona quando o reverse proxy encaminha `/ws`; o backoff cobre o contrário).

### 🟡 Limpeza
- `pnpm-lock.yaml` ressincronizado com o `package.json` (remove a dependência fantasma `i@^0.3.7`) — `pnpm install --frozen-lockfile` volta a funcionar e a linha comentada no Dockerfile pode ser reativada.

## Verificação
- `next build --turbopack` passa com todas as rotas geradas
- `pnpm install --frozen-lockfile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_