### PR TITLE
feat(admin): cadastro de funcionário + gestão de setores ligada à API

### DIFF
--- a/app/(dashboard)/admin/_components/FormFuncionarioCreate.tsx
+++ b/app/(dashboard)/admin/_components/FormFuncionarioCreate.tsx
@@ -1,0 +1,332 @@
+"use client";
+import { apiFetch } from "../../../../utils/api";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  CheckCircle2,
+  Copy,
+  Eye,
+  EyeOff,
+  Loader2,
+  Mail,
+  RotateCcw,
+  Shield,
+} from "lucide-react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+const PAPEIS = [
+  { value: "BACKOFFICE",    label: "Backoffice",    desc: "Atende chamados e gerencia solicitações." },
+  { value: "TECNICO",       label: "Técnico",       desc: "Resolve chamados técnicos atribuídos ao setor." },
+  { value: "ADMINISTRADOR", label: "Administrador", desc: "Acesso total: usuários, setores e configurações." },
+] as const;
+
+type PapelValue = (typeof PAPEIS)[number]["value"];
+
+type Props = {
+  onSuccess?: (createdUser: any) => void;
+  onCancel?: () => void;
+};
+
+type SuccessInfo = {
+  nome: string;
+  email: string;
+  papel: string;
+  senha: string;
+};
+
+const inputCls =
+  "mt-1 w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]";
+const labelCls = "block text-sm text-muted-foreground";
+
+export default function FormFuncionarioCreate({ onSuccess, onCancel }: Props) {
+  const [nome, setNome] = useState("");
+  const [emailPessoal, setEmailPessoal] = useState("");
+  const [papel, setPapel] = useState<PapelValue | "">("");
+
+  const [senha, setSenha] = useState("");
+  const [mostrarSenha, setMostrarSenha] = useState(false);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [successInfo, setSuccessInfo] = useState<SuccessInfo | null>(null);
+  const [lastCreated, setLastCreated] = useState<any>(null);
+  const [copied, setCopied] = useState(false);
+
+  const senhaValida = senha.trim().length >= 8;
+
+  const canSubmit = useMemo(() => {
+    const nomeOk = nome.trim().length >= 2;
+    const mailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailPessoal);
+    const papelOk = papel !== "";
+    return nomeOk && mailOk && papelOk && senhaValida && !submitting;
+  }, [nome, emailPessoal, papel, senhaValida, submitting]);
+
+  function handleCopiarSenha(valor: string) {
+    navigator.clipboard.writeText(valor).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  function resetForm() {
+    setNome(""); setEmailPessoal(""); setPapel("");
+    setSenha(""); setMostrarSenha(false);
+    setSuccessInfo(null); setLastCreated(null); setCopied(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    try {
+      setSubmitting(true);
+
+      const payload: Record<string, any> = {
+        nome: nome.trim(),
+        emailPessoal: emailPessoal.trim(),
+        papel,
+        ativo: true,
+        senha: senha.trim(),
+      };
+
+      const res = await apiFetch(`${API_URL}/usuarios`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        try {
+          const json = JSON.parse(text);
+          if (json?.issues?.length) {
+            throw new Error(json.issues.map((i: any) => `${i.path}: ${i.message}`).join(" | "));
+          }
+          throw new Error(json?.message || json?.error || `Falha ao criar funcionário (${res.status})`);
+        } catch {
+          throw new Error(text || `Falha ao criar funcionário (${res.status})`);
+        }
+      }
+
+      const created = await res.json();
+      const papelLabel = PAPEIS.find((p) => p.value === payload.papel)?.label ?? payload.papel;
+
+      setLastCreated(created);
+      setSuccessInfo({
+        nome: nome.trim() || created?.nome || "",
+        email: emailPessoal.trim(),
+        papel: papelLabel,
+        senha: senha.trim(),
+      });
+    } catch (err: any) {
+      console.error(err);
+      toast.error(err?.message ?? "Erro ao criar funcionário");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  /* ── Tela de sucesso ── */
+  if (successInfo) {
+    return (
+      <div className="space-y-5">
+        <div className="flex flex-col items-center gap-3 py-4">
+          <CheckCircle2 className="size-10 text-emerald-500" />
+          <div className="text-center">
+            <p className="font-semibold text-base">Funcionário cadastrado com sucesso!</p>
+            {successInfo.nome && (
+              <p className="text-sm text-muted-foreground mt-0.5">{successInfo.nome}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-[var(--border)] divide-y divide-[var(--border)]">
+          <div className="px-4 py-2.5 flex items-center justify-between gap-4">
+            <span className="text-xs text-muted-foreground w-24 shrink-0">Papel</span>
+            <span className="text-sm font-medium flex-1 text-right">{successInfo.papel}</span>
+          </div>
+          <div className="px-4 py-2.5 flex items-center justify-between gap-4">
+            <span className="text-xs text-muted-foreground w-24 shrink-0">E-mail</span>
+            <span className="text-sm flex-1 text-right truncate">{successInfo.email}</span>
+          </div>
+          <div className="px-4 py-2.5 flex items-center justify-between gap-4">
+            <span className="text-xs text-muted-foreground w-24 shrink-0">Senha inicial</span>
+            <div className="flex items-center gap-2 flex-1 justify-end">
+              <span className="text-sm font-medium font-mono bg-[var(--muted)] px-2 py-0.5 rounded">
+                {successInfo.senha}
+              </span>
+              <button
+                type="button"
+                onClick={() => handleCopiarSenha(successInfo.senha)}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition"
+                title="Copiar senha"
+              >
+                {copied ? <CheckCircle2 className="size-3.5 text-emerald-500" /> : <Copy className="size-3.5" />}
+                {copied ? "Copiado!" : "Copiar"}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-xs text-muted-foreground rounded-lg bg-[var(--muted)] px-3 py-2">
+          O funcionário deverá trocar a senha no primeiro acesso. Compartilhe as credenciais acima com segurança.
+        </p>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={resetForm}
+            className="inline-flex items-center gap-2 h-9 px-4 rounded-lg border border-[var(--border)] text-sm hover:bg-[var(--muted)]"
+          >
+            <RotateCcw className="size-3.5" /> Cadastrar outro
+          </button>
+          {(onSuccess || onCancel) && (
+            <button
+              type="button"
+              onClick={() => onSuccess ? onSuccess(lastCreated) : onCancel?.()}
+              className="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-sm hover:brightness-95"
+            >
+              Concluído
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {/* ── Seção: Identificação ── */}
+      <fieldset className="space-y-3">
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Identificação
+        </legend>
+
+        <div>
+          <label className={labelCls}>Nome completo *</label>
+          <input
+            className={inputCls}
+            placeholder="Ex.: Ana Pereira"
+            value={nome}
+            onChange={(e) => setNome(e.target.value)}
+            required
+            minLength={2}
+            maxLength={160}
+          />
+        </div>
+
+        <div>
+          <label className={labelCls}>E-mail *</label>
+          <div className="relative">
+            <input
+              type="email"
+              className={inputCls + " pr-9"}
+              placeholder="nome.sobrenome@fatec.sp.gov.br"
+              value={emailPessoal}
+              onChange={(e) => setEmailPessoal(e.target.value)}
+              required
+            />
+            <Mail className="absolute right-3 top-1/2 -translate-y-1/2 mt-0.5 size-4 text-muted-foreground pointer-events-none" />
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Usado para login e para o link de primeiro acesso.
+          </p>
+        </div>
+      </fieldset>
+
+      {/* ── Seção: Papel ── */}
+      <fieldset className="space-y-3">
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Papel de acesso *
+        </legend>
+
+        <div className="rounded-lg border border-[var(--border)] divide-y divide-[var(--border)]">
+          {PAPEIS.map((p) => (
+            <label
+              key={p.value}
+              className="flex items-center gap-3 px-4 py-3 cursor-pointer select-none hover:bg-[var(--muted)]/50"
+            >
+              <input
+                type="radio"
+                name="papel"
+                value={p.value}
+                checked={papel === p.value}
+                onChange={() => setPapel(p.value)}
+                className="size-4 accent-[var(--primary)]"
+              />
+              <Shield className="size-4 text-muted-foreground shrink-0" />
+              <div>
+                <p className="text-sm font-medium leading-tight">{p.label}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{p.desc}</p>
+              </div>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* ── Seção: Senha inicial ── */}
+      <fieldset className="space-y-3">
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Senha inicial *
+        </legend>
+
+        <div className="space-y-1.5">
+          <label className={labelCls}>
+            Senha{" "}
+            <span className="text-muted-foreground/60">(mín. 8 caracteres)</span>
+          </label>
+          <div className="relative">
+            <input
+              type={mostrarSenha ? "text" : "password"}
+              className={inputCls + " pr-10 mt-0"}
+              placeholder="Digite a senha inicial"
+              value={senha}
+              onChange={(e) => setSenha(e.target.value)}
+              minLength={8}
+              required
+              autoComplete="new-password"
+            />
+            <button
+              type="button"
+              onClick={() => setMostrarSenha((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              tabIndex={-1}
+              aria-label={mostrarSenha ? "Ocultar senha" : "Mostrar senha"}
+            >
+              {mostrarSenha ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+            </button>
+          </div>
+          {senha && senha.length < 8 && (
+            <p className="text-xs text-destructive">A senha deve ter pelo menos 8 caracteres.</p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            O funcionário deverá trocar esta senha no primeiro acesso.
+          </p>
+        </div>
+      </fieldset>
+
+      {/* ── Ações ── */}
+      <div className="flex items-center justify-end gap-2 pt-2 border-t border-[var(--border)]">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="h-10 px-4 rounded-lg border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
+          >
+            Cancelar
+          </button>
+        )}
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex items-center gap-2 h-10 px-4 rounded-lg bg-primary text-primary-foreground text-sm hover:brightness-95 disabled:opacity-60"
+        >
+          {submitting ? (
+            <><Loader2 className="size-4 animate-spin" /> Salvando…</>
+          ) : (
+            "Criar funcionário"
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(dashboard)/admin/funcionarios/novo/page.tsx
+++ b/app/(dashboard)/admin/funcionarios/novo/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import FormFuncionarioCreate from "../../_components/FormFuncionarioCreate";
+
+export default function NovoFuncionarioPage() {
+  const router = useRouter();
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-5">
+      <div>
+        <Link
+          href="/admin/funcionarios"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" /> Voltar para funcionários
+        </Link>
+        <h1 className="font-grotesk mt-2 text-2xl font-semibold tracking-tight">
+          Cadastrar funcionário
+        </h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Crie uma conta de equipe (backoffice, técnico ou administrador).
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border)] bg-card p-5 sm:p-6">
+        <FormFuncionarioCreate
+          onSuccess={() => router.push("/admin/funcionarios")}
+          onCancel={() => router.push("/admin/funcionarios")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/admin/setores/page.tsx
+++ b/app/(dashboard)/admin/setores/page.tsx
@@ -1,26 +1,30 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
-  Search, Plus, Building2, Users, Pencil, Trash2, X, Check, ChevronRight,
-  User as UserIcon, BadgeCheck, Filter, ArrowRightLeft
+  Search, Plus, Building2, Users, Pencil, Trash2, X, Check,
+  User as UserIcon, BadgeCheck, Filter, ArrowRightLeft, Loader2
 } from "lucide-react";
+import { toast } from "sonner";
 import { cx } from '../../../../utils/cx'
-/* ===================== Tipos alinhados ao seu schema ===================== */
-type PapelKey = "BACKOFFICE" | "TECNICO" | "ADMINISTRADOR";
+import { apiFetch } from "../../../../utils/api";
 
+const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+/* ===================== Tipos alinhados ao schema ===================== */
 type PapelCatalogo = {
   id: string;
-  nome: PapelKey;           // em seu schema o nome é único
+  nome: string;
   descricao?: string | null;
 };
 
 type Usuario = {
   id: string;
   nome?: string | null;
-  emailEducacional: string;
+  emailEducacional?: string | null;
   emailPessoal?: string | null;
+  papel?: string | null;
   ativo: boolean;
 };
 
@@ -30,54 +34,25 @@ type Setor = {
   descricao?: string | null;
 };
 
-type UsuarioSetor = {
-  id: string;
+/** Vínculo usuário↔setor, com usuário e papel embutidos (include do backend). */
+type Membro = {
+  id: string;           // id do vínculo (usuarioSetor)
   usuarioId: string;
   setorId: string;
   papelId?: string | null;
+  usuario: Usuario;
+  papel?: PapelCatalogo | null;
 };
 
-/* ===================== MOCK ===================== */
-const PAPEIS: PapelCatalogo[] = [
-  { id: "p1", nome: "BACKOFFICE" },
-  { id: "p2", nome: "TECNICO" },
-  { id: "p3", nome: "ADMINISTRADOR" },
-];
-
-const SETORES: Setor[] = [
-  { id: "s1", nome: "Secretaria" },
-  { id: "s2", nome: "Financeiro" },
-  { id: "s3", nome: "TI Acadêmica" },
-];
-
-const USERS: Usuario[] = [
-  { id: "u1", nome: "Ana Pereira", emailEducacional: "ana.pereira@fatec.sp.gov.br", ativo: true },
-  { id: "u2", nome: "Bruno Santos", emailEducacional: "bruno.santos@fatec.sp.gov.br", ativo: true },
-  { id: "u3", nome: "Carla Mendes", emailEducacional: "carla.mendes@fatec.sp.gov.br", ativo: true },
-  { id: "u4", nome: "Diego Lima", emailEducacional: "diego.lima@fatec.sp.gov.br", ativo: false },
-];
-
-const USUARIOS_SETORES: UsuarioSetor[] = [
-  { id: "us1", usuarioId: "u1", setorId: "s1", papelId: "p3" }, // Ana — Secretaria — ADMIN
-  { id: "us2", usuarioId: "u2", setorId: "s3", papelId: "p2" }, // Bruno — TI — TECNICO
-  { id: "us3", usuarioId: "u3", setorId: "s2", papelId: "p1" }, // Carla — Financeiro — BACKOFFICE
-];
-
-/* ===================== Utils ===================== */
-const papelById = (id?: string | null) => PAPEIS.find(p => p.id === id) ?? null;
+/* ===================== Helpers de e-mail ===================== */
+const emailDe = (u: Usuario) => u.emailEducacional ?? u.emailPessoal ?? "—";
 
 /* ===================== Chips / Badges ===================== */
-function PapelBadge({ papelId }: { papelId?: string | null }) {
-  const papel = papelById(papelId)?.nome;
-  const map: Record<PapelKey, string> = {
-    BACKOFFICE: "bg-slate-500/12 text-slate-600 border-slate-500/30",
-    TECNICO: "bg-indigo-500/12 text-indigo-600 border-indigo-500/30",
-    ADMINISTRADOR: "bg-emerald-500/12 text-emerald-600 border-emerald-500/30",
-  };
-  if (!papel) return <span className="text-xs text-muted-foreground">—</span>;
+function PapelBadge({ nome }: { nome?: string | null }) {
+  if (!nome) return <span className="text-xs text-muted-foreground">—</span>;
   return (
-    <span className={cx("inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-semibold border", map[papel])}>
-      <BadgeCheck className="size-3" /> {papel}
+    <span className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11px] font-semibold border bg-indigo-500/12 text-indigo-600 border-indigo-500/30">
+      <BadgeCheck className="size-3" /> {nome}
     </span>
   );
 }
@@ -90,83 +65,210 @@ function AtivoDot({ ativo }: { ativo: boolean }) {
 
 /* ===================== Página ===================== */
 export default function SetoresPage() {
-  // Em um app real, estes estados viriam do backend (fetch + useEffect).
-  const [setores, setSetores] = useState<Setor[]>(SETORES);
-  const [usuarios, setUsuarios] = useState<Usuario[]>(USERS);
-  const [rel, setRel] = useState<UsuarioSetor[]>(USUARIOS_SETORES);
+  const [setores, setSetores] = useState<Setor[]>([]);
+  const [papeis, setPapeis] = useState<PapelCatalogo[]>([]);
+  const [usuarios, setUsuarios] = useState<Usuario[]>([]);
+  const [membros, setMembros] = useState<Membro[]>([]);
+
+  const [loadingSetores, setLoadingSetores] = useState(true);
+  const [loadingMembros, setLoadingMembros] = useState(false);
+  const [busy, setBusy] = useState(false);
 
   const [qSetor, setQSetor] = useState("");
-  const [currentSetorId, setCurrentSetorId] = useState<string>(setores[0]?.id ?? "");
+  const [currentSetorId, setCurrentSetorId] = useState<string>("");
   const currentSetor = setores.find(s => s.id === currentSetorId) ?? null;
 
   const [drawerOpen, setDrawerOpen] = useState(false);
 
-  const setoresFiltrados = useMemo(() => {
-    return setores
-      .map(s => ({
-        ...s,
-        count: rel.filter(r => r.setorId === s.id).length,
-      }))
-      .filter(s => !qSetor || s.nome.toLowerCase().includes(qSetor.toLowerCase()));
-  }, [setores, rel, qSetor]);
+  /* ── Carga inicial: setores, papéis e funcionários ── */
+  const carregarSetores = useCallback(async (selecionar?: string) => {
+    setLoadingSetores(true);
+    try {
+      const res = await apiFetch(`${API_URL}/admin/setores?perPage=100`, { cache: "no-store" });
+      if (!res.ok) throw new Error(`Falha ao carregar setores (${res.status})`);
+      const json = await res.json();
+      const lista: Setor[] = json?.data ?? [];
+      setSetores(lista);
+      setCurrentSetorId(prev => selecionar ?? (lista.some(s => s.id === prev) ? prev : lista[0]?.id ?? ""));
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao carregar setores");
+    } finally {
+      setLoadingSetores(false);
+    }
+  }, []);
 
-  const membrosDoSetor = useMemo(() => {
-    if (!currentSetor) return [];
-    const rows = rel.filter(r => r.setorId === currentSetor.id)
-      .map(r => {
-        const u = usuarios.find(x => x.id === r.usuarioId)!;
-        return { usId: r.id, usuario: u, papelId: r.papelId };
+  useEffect(() => {
+    carregarSetores();
+
+    apiFetch(`${API_URL}/admin/papeis`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => setPapeis(Array.isArray(data) ? data : (data?.data ?? [])))
+      .catch(() => {});
+
+    // Candidatos para atribuição: apenas contas de equipe (não-aluno) e ativas.
+    apiFetch(`${API_URL}/usuarios?perPage=100&ativo=true`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        const items: Usuario[] = json?.items ?? [];
+        setUsuarios(items.filter((u) => u.papel && u.papel !== "USUARIO"));
       })
-      .sort((a, b) => (a.usuario.nome ?? "").localeCompare(b.usuario.nome ?? ""));
-    return rows;
-  }, [currentSetor, rel, usuarios]);
+      .catch(() => {});
+  }, [carregarSetores]);
 
-  function criarSetor() {
-    const nome = prompt("Nome do novo setor:");
-    if (!nome) return;
-    const novo: Setor = { id: `s${Date.now()}`, nome };
-    setSetores(prev => [...prev, novo]);
-    setCurrentSetorId(novo.id);
-  }
-
-  function renomearSetor() {
-    if (!currentSetor) return;
-    const nome = prompt("Novo nome do setor:", currentSetor.nome);
-    if (!nome) return;
-    setSetores(prev => prev.map(s => (s.id === currentSetor.id ? { ...s, nome } : s)));
-  }
-
-  function removerSetor() {
-    if (!currentSetor) return;
-    const temMembros = rel.some(r => r.setorId === currentSetor.id);
-    if (temMembros && !confirm("Este setor possui membros. Remover mesmo assim? As relações serão excluídas.")) {
-      return;
+  /* ── Membros do setor selecionado ── */
+  const carregarMembros = useCallback(async (setorId: string) => {
+    if (!setorId) { setMembros([]); return; }
+    setLoadingMembros(true);
+    try {
+      const res = await apiFetch(`${API_URL}/admin/setores/${setorId}/usuarios?perPage=100`, { cache: "no-store" });
+      if (!res.ok) throw new Error(`Falha ao carregar membros (${res.status})`);
+      const json = await res.json();
+      setMembros(json?.data ?? []);
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao carregar membros do setor");
+      setMembros([]);
+    } finally {
+      setLoadingMembros(false);
     }
-    setRel(prev => prev.filter(r => r.setorId !== currentSetor.id));
-    setSetores(prev => prev.filter(s => s.id !== currentSetor.id));
-    setCurrentSetorId(setores.find(s => s.id !== currentSetor.id)?.id ?? "");
-  }
+  }, []);
 
-  function trocarPapel(usId: string, novoPapelId: string) {
-    setRel(prev => prev.map(r => (r.id === usId ? { ...r, papelId: novoPapelId } : r)));
-  }
+  useEffect(() => {
+    carregarMembros(currentSetorId);
+  }, [currentSetorId, carregarMembros]);
 
-  function removerMembro(usId: string) {
-    setRel(prev => prev.filter(r => r.id !== usId));
-  }
+  const setoresFiltrados = useMemo(() => {
+    return setores.filter(s => !qSetor || s.nome.toLowerCase().includes(qSetor.toLowerCase()));
+  }, [setores, qSetor]);
 
-  function atribuirUsuariosAoSetor(userIds: string[], papelId?: string | null) {
-    if (!currentSetor) return;
-    const novos: UsuarioSetor[] = [];
-    for (const uid of userIds) {
-      const existe = rel.some(r => r.setorId === currentSetor.id && r.usuarioId === uid);
-      if (!existe) {
-        novos.push({ id: `us${Date.now()}-${uid}`, usuarioId: uid, setorId: currentSetor.id, papelId: papelId ?? null });
-      }
+  const membrosOrdenados = useMemo(
+    () => [...membros].sort((a, b) => (a.usuario.nome ?? "").localeCompare(b.usuario.nome ?? "")),
+    [membros],
+  );
+
+  /* ── CRUD de setores ── */
+  async function criarSetor() {
+    const nome = prompt("Nome do novo setor:")?.trim();
+    if (!nome) return;
+    setBusy(true);
+    try {
+      const res = await apiFetch(`${API_URL}/admin/setores`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nome }),
+      });
+      if (!res.ok) throw new Error(`Falha ao criar setor (${res.status})`);
+      const novo = await res.json();
+      toast.success("Setor criado.");
+      await carregarSetores(novo?.id);
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao criar setor");
+    } finally {
+      setBusy(false);
     }
-    if (novos.length === 0) return;
-    setRel(prev => [...prev, ...novos]);
   }
+
+  async function renomearSetor() {
+    if (!currentSetor) return;
+    const nome = prompt("Novo nome do setor:", currentSetor.nome)?.trim();
+    if (!nome || nome === currentSetor.nome) return;
+    setBusy(true);
+    try {
+      const res = await apiFetch(`${API_URL}/admin/setores/${currentSetor.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nome }),
+      });
+      if (!res.ok) throw new Error(`Falha ao renomear (${res.status})`);
+      toast.success("Setor renomeado.");
+      await carregarSetores(currentSetor.id);
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao renomear setor");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removerSetor() {
+    if (!currentSetor) return;
+    const temMembros = membros.length > 0;
+    const msg = temMembros
+      ? "Este setor possui membros. Remover mesmo assim? Os vínculos serão excluídos."
+      : `Remover o setor "${currentSetor.nome}"?`;
+    if (!confirm(msg)) return;
+    setBusy(true);
+    try {
+      const res = await apiFetch(`${API_URL}/admin/setores/${currentSetor.id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error(`Falha ao remover (${res.status})`);
+      toast.success("Setor removido.");
+      await carregarSetores();
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao remover setor");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /* ── Membros ── */
+  async function trocarPapel(usuarioSetorId: string, novoPapelId: string) {
+    setBusy(true);
+    try {
+      const res = await apiFetch(`${API_URL}/admin/usuarios-setores/${usuarioSetorId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ papelId: novoPapelId || null }),
+      });
+      if (!res.ok) throw new Error(`Falha ao alterar papel (${res.status})`);
+      await carregarMembros(currentSetorId);
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao alterar papel");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removerMembro(usuarioSetorId: string) {
+    if (!confirm("Remover este funcionário do setor?")) return;
+    setBusy(true);
+    try {
+      const res = await apiFetch(`${API_URL}/admin/usuarios-setores/${usuarioSetorId}`, { method: "DELETE" });
+      if (!res.ok) throw new Error(`Falha ao remover membro (${res.status})`);
+      toast.success("Membro removido do setor.");
+      await carregarMembros(currentSetorId);
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao remover membro");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function atribuirUsuariosAoSetor(userIds: string[], papelId?: string | null) {
+    if (!currentSetor || userIds.length === 0) return;
+    setBusy(true);
+    try {
+      const resultados = await Promise.allSettled(
+        userIds.map((uid) =>
+          apiFetch(`${API_URL}/admin/usuarios/${uid}/setores`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ setorId: currentSetor.id, papelId: papelId ?? null }),
+          }).then((r) => {
+            if (!r.ok) throw new Error(String(r.status));
+          }),
+        ),
+      );
+      const falhas = resultados.filter((r) => r.status === "rejected").length;
+      if (falhas === 0) toast.success("Funcionários atribuídos ao setor.");
+      else toast.warning(`${userIds.length - falhas} atribuído(s), ${falhas} com erro.`);
+      setDrawerOpen(false);
+      await carregarMembros(currentSetorId);
+    } catch (e: any) {
+      toast.error(e?.message ?? "Erro ao atribuir funcionários");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const idsNoSetor = useMemo(() => new Set(membros.map((m) => m.usuarioId)), [membros]);
 
   return (
     <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">
@@ -185,50 +287,59 @@ export default function SetoresPage() {
             </div>
           </div>
 
-          <ul className="mt-2 space-y-1">
-            {setoresFiltrados.map((s) => (
-              <li key={s.id}>
-                <button
-                  className={cx(
-                    "w-full text-left rounded-lg px-3 py-2 transition flex items-center justify-between",
-                    currentSetorId === s.id ? "bg-primary text-primary-foreground shadow-sm" : "hover:bg-[var(--muted)]/70"
-                  )}
-                  onClick={() => setCurrentSetorId(s.id)}
-                >
-                  <span className="flex items-center gap-2">
-                    <Building2 className="size-4 opacity-80" />
-                    <span className="font-medium">{s.nome}</span>
-                  </span>
-                  <span className="inline-flex items-center gap-1 text-xs rounded-md border bg-background px-1.5 py-0.5">
-                    <Users className="size-3" /> {s.count}
-                  </span>
-                </button>
-              </li>
-            ))}
-            {setoresFiltrados.length === 0 && (
-              <li className="px-3 py-8 text-center text-sm text-muted-foreground">Nenhum setor encontrado.</li>
-            )}
-          </ul>
+          {loadingSetores ? (
+            <div className="px-3 py-10 flex items-center justify-center text-muted-foreground">
+              <Loader2 className="size-5 animate-spin" />
+            </div>
+          ) : (
+            <ul className="mt-2 space-y-1">
+              {setoresFiltrados.map((s) => (
+                <li key={s.id}>
+                  <button
+                    className={cx(
+                      "w-full text-left rounded-lg px-3 py-2 transition flex items-center justify-between",
+                      currentSetorId === s.id ? "bg-primary text-primary-foreground shadow-sm" : "hover:bg-[var(--muted)]/70"
+                    )}
+                    onClick={() => setCurrentSetorId(s.id)}
+                  >
+                    <span className="flex items-center gap-2">
+                      <Building2 className="size-4 opacity-80" />
+                      <span className="font-medium">{s.nome}</span>
+                    </span>
+                    {currentSetorId === s.id && (
+                      <span className="inline-flex items-center gap-1 text-xs rounded-md border bg-background/20 px-1.5 py-0.5">
+                        <Users className="size-3" /> {membros.length}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              ))}
+              {setoresFiltrados.length === 0 && (
+                <li className="px-3 py-8 text-center text-sm text-muted-foreground">Nenhum setor encontrado.</li>
+              )}
+            </ul>
+          )}
 
           {/* Ações do catálogo */}
           <div className="mt-3 flex items-center justify-between px-2">
             <button
               onClick={criarSetor}
-              className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-primary text-primary-foreground text-sm hover:brightness-95"
+              disabled={busy}
+              className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-primary text-primary-foreground text-sm hover:brightness-95 disabled:opacity-50"
             >
               <Plus className="size-4" /> Novo setor
             </button>
             <div className="flex items-center gap-2">
               <button
                 onClick={renomearSetor}
-                disabled={!currentSetor}
+                disabled={!currentSetor || busy}
                 className="inline-flex items-center gap-2 h-9 px-3 rounded-md border border-[var(--border)] text-sm hover:bg-[var(--muted)] disabled:opacity-50"
               >
                 <Pencil className="size-4" /> Renomear
               </button>
               <button
                 onClick={removerSetor}
-                disabled={!currentSetor}
+                disabled={!currentSetor || busy}
                 className="inline-flex items-center gap-2 h-9 px-3 rounded-md border border-[var(--border)] text-sm hover:bg-[var(--muted)] disabled:opacity-50"
               >
                 <Trash2 className="size-4" /> Remover
@@ -239,8 +350,8 @@ export default function SetoresPage() {
 
         {/* Dica UX */}
         <div className="mt-4 rounded-xl border border-[var(--border)] bg-card p-4 text-sm text-muted-foreground">
-          Dica: cada funcionário pode ter <b>papéis diferentes por setor</b> (ex.: Técnico em TI, Backoffice na Secretaria).  
-          Use o botão <i>Atribuir funcionários</i> para criar relações <code>UsuarioSetor</code>.
+          Dica: cada funcionário pode ter <b>papéis diferentes por setor</b> (ex.: Técnico em TI, Backoffice na Secretaria).
+          Use o botão <i>Atribuir funcionários</i> para criar os vínculos.
         </div>
       </aside>
 
@@ -248,7 +359,7 @@ export default function SetoresPage() {
       <section className="xl:col-span-8">
         {!currentSetor ? (
           <div className="rounded-xl border border-[var(--border)] bg-card p-6 text-center text-muted-foreground">
-            Selecione um setor à esquerda.
+            {loadingSetores ? "Carregando…" : "Nenhum setor cadastrado. Crie o primeiro à esquerda."}
           </div>
         ) : (
           <div className="space-y-4">
@@ -261,7 +372,8 @@ export default function SetoresPage() {
               <div className="flex items-center gap-2">
                 <button
                   onClick={() => setDrawerOpen(true)}
-                  className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-primary text-primary-foreground text-sm hover:brightness-95"
+                  disabled={busy}
+                  className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-primary text-primary-foreground text-sm hover:brightness-95 disabled:opacity-50"
                 >
                   <Plus className="size-4" /> Atribuir funcionários
                 </button>
@@ -272,7 +384,7 @@ export default function SetoresPage() {
             <div className="rounded-xl border border-[var(--border)] bg-card overflow-hidden">
               <div className="px-4 py-3 bg-[var(--muted)] text-sm font-semibold flex items-center justify-between">
                 <span>Membros do setor</span>
-                <span className="text-muted-foreground font-normal">{membrosDoSetor.length} membro(s)</span>
+                <span className="text-muted-foreground font-normal">{membros.length} membro(s)</span>
               </div>
               <div className="overflow-x-auto">
                 <table className="min-w-full text-sm">
@@ -285,38 +397,45 @@ export default function SetoresPage() {
                     </tr>
                   </thead>
                   <tbody>
-                    {membrosDoSetor.map((m) => (
-                      <tr key={m.usId} className="border-t border-[var(--border)]">
+                    {loadingMembros ? (
+                      <tr>
+                        <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
+                          <Loader2 className="size-5 animate-spin inline" />
+                        </td>
+                      </tr>
+                    ) : membrosOrdenados.map((m) => (
+                      <tr key={m.id} className="border-t border-[var(--border)]">
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-2">
                             <AtivoDot ativo={m.usuario.ativo} />
                             <UserIcon className="size-4 text-muted-foreground" />
                             <div className="min-w-0">
                               <div className="font-medium leading-tight">{m.usuario.nome ?? "—"}</div>
-                              <div className="md:hidden text-xs text-muted-foreground">{m.usuario.emailEducacional}</div>
+                              <div className="md:hidden text-xs text-muted-foreground">{emailDe(m.usuario)}</div>
                             </div>
                           </div>
                         </td>
-                        <td className="px-4 py-3 hidden md:table-cell">{m.usuario.emailEducacional}</td>
+                        <td className="px-4 py-3 hidden md:table-cell">{emailDe(m.usuario)}</td>
                         <td className="px-4 py-3">
-                          <PapelBadge papelId={m.papelId} />
+                          <PapelBadge nome={m.papel?.nome} />
                         </td>
                         <td className="px-4 py-3 text-right">
                           <div className="inline-flex items-center gap-1">
-                            {/* Trocar papel (dropdown simples) */}
                             <select
-                              className="h-9 px-2 rounded-md border border-[var(--border)] bg-background text-sm"
+                              className="h-9 px-2 rounded-md border border-[var(--border)] bg-background text-sm disabled:opacity-50"
                               value={m.papelId ?? ""}
-                              onChange={(e) => trocarPapel(m.usId, e.target.value || "")}
+                              disabled={busy}
+                              onChange={(e) => trocarPapel(m.id, e.target.value)}
                             >
-                              <option value="">—</option>
-                              {PAPEIS.map((p) => (
+                              <option value="">— sem papel —</option>
+                              {papeis.map((p) => (
                                 <option key={p.id} value={p.id}>{p.nome}</option>
                               ))}
                             </select>
                             <button
-                              className="h-9 px-3 rounded-md hover:bg-[var(--muted)]"
-                              onClick={() => removerMembro(m.usId)}
+                              className="h-9 px-3 rounded-md hover:bg-[var(--muted)] disabled:opacity-50"
+                              onClick={() => removerMembro(m.id)}
+                              disabled={busy}
                               title="Remover do setor"
                             >
                               Remover
@@ -325,7 +444,7 @@ export default function SetoresPage() {
                         </td>
                       </tr>
                     ))}
-                    {membrosDoSetor.length === 0 && (
+                    {!loadingMembros && membrosOrdenados.length === 0 && (
                       <tr>
                         <td colSpan={4} className="px-4 py-10 text-center text-muted-foreground">
                           Nenhum membro neste setor.
@@ -358,13 +477,11 @@ export default function SetoresPage() {
         <AssignDrawer
           onClose={() => setDrawerOpen(false)}
           usuarios={usuarios}
-          rel={rel}
+          idsNoSetor={idsNoSetor}
           setor={currentSetor}
-          papeis={PAPEIS}
-          onAssign={(ids, papel) => {
-            atribuirUsuariosAoSetor(ids, papel);
-            setDrawerOpen(false);
-          }}
+          papeis={papeis}
+          busy={busy}
+          onAssign={atribuirUsuariosAoSetor}
         />
       )}
     </div>
@@ -375,51 +492,47 @@ export default function SetoresPage() {
 function AssignDrawer({
   onClose,
   usuarios,
-  rel,
+  idsNoSetor,
   setor,
   papeis,
+  busy,
   onAssign,
 }: {
   onClose: () => void;
   usuarios: Usuario[];
-  rel: UsuarioSetor[];
+  idsNoSetor: Set<string>;
   setor: Setor;
   papeis: PapelCatalogo[];
+  busy: boolean;
   onAssign: (userIds: string[], papelId?: string | null) => void;
 }) {
   const [q, setQ] = useState("");
   const [papelId, setPapelId] = useState<string>("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  const jaNoSetor = new Set(rel.filter(r => r.setorId === setor.id).map(r => r.usuarioId));
-
   const candidatos = useMemo(() => {
     return usuarios
-      .filter(u => !jaNoSetor.has(u.id))
+      .filter(u => !idsNoSetor.has(u.id))
       .filter(u =>
         !q ||
-        u.emailEducacional.toLowerCase().includes(q.toLowerCase()) ||
+        emailDe(u).toLowerCase().includes(q.toLowerCase()) ||
         (u.nome?.toLowerCase().includes(q.toLowerCase()) ?? false)
       )
       .sort((a, b) => (a.nome ?? "").localeCompare(b.nome ?? ""));
-  }, [usuarios, q, jaNoSetor]);
+  }, [usuarios, q, idsNoSetor]);
 
   function toggle(id: string) {
     setSelected(prev => {
       const n = new Set(prev);
-      n.has(id) ? n.delete(id) : n.add(id);
+      if (n.has(id)) n.delete(id); else n.add(id);
       return n;
     });
-  }
-
-  function confirmAssign() {
-    onAssign(Array.from(selected), papelId || null);
   }
 
   return (
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/30" onClick={onClose} />
-      <div className="absolute right-0 top-0 h-full w-[92%] sm:w-[520px] bg-background shadow-xl p-4">
+      <div className="absolute right-0 top-0 h-full w-[92%] sm:w-[520px] bg-background shadow-xl p-4 overflow-y-auto">
         <div className="flex items-center justify-between mb-2">
           <div className="font-grotesk font-semibold">Atribuir funcionários — {setor.nome}</div>
           <button
@@ -481,15 +594,15 @@ function AssignDrawer({
                         <AtivoDot ativo={u.ativo} />
                         <span className="font-medium">{u.nome ?? "—"}</span>
                       </div>
-                      <div className="sm:hidden text-xs text-muted-foreground">{u.emailEducacional}</div>
+                      <div className="sm:hidden text-xs text-muted-foreground">{emailDe(u)}</div>
                     </td>
-                    <td className="px-3 py-2 hidden sm:table-cell">{u.emailEducacional}</td>
+                    <td className="px-3 py-2 hidden sm:table-cell">{emailDe(u)}</td>
                   </tr>
                 ))}
                 {candidatos.length === 0 && (
                   <tr>
                     <td colSpan={3} className="px-3 py-8 text-center text-muted-foreground">
-                      Nenhum candidato disponível com esse filtro.
+                      Nenhum funcionário disponível com esse filtro.
                     </td>
                   </tr>
                 )}
@@ -507,18 +620,18 @@ function AssignDrawer({
                 Cancelar
               </button>
               <button
-                onClick={confirmAssign}
-                disabled={selected.size === 0}
+                onClick={() => onAssign(Array.from(selected), papelId || null)}
+                disabled={selected.size === 0 || busy}
                 className="inline-flex items-center gap-2 h-9 px-3 rounded-md bg-primary text-primary-foreground text-sm hover:brightness-95 disabled:opacity-50"
               >
-                <Check className="size-4" /> Atribuir ao setor
+                {busy ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />} Atribuir ao setor
               </button>
             </div>
           </div>
         </div>
 
         <div className="mt-3 text-xs text-muted-foreground">
-          Dica: se nenhum papel for escolhido, a relação é criada sem papel e pode ser definida depois.
+          Dica: se nenhum papel for escolhido, o vínculo é criado sem papel e pode ser definido depois.
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Resumo

Resolve dois itens do mapeamento de auditoria: um cadastro quebrado e a maior tela mockada.

### 1. Cadastro de funcionário (antes: 404)
O botão "Cadastrar funcionário" apontava para `/admin/funcionarios/novo`, rota que não existia — clicar dava 404, sem forma de cadastrar equipe pela interface.

- Nova página `app/(dashboard)/admin/funcionarios/novo/page.tsx` + componente `FormFuncionarioCreate` (nome, e-mail, papel `BACKOFFICE`/`TECNICO`/`ADMINISTRADOR` e senha obrigatória), enviando `POST /usuarios`.
- Espelha o padrão de validação, erro e tela de sucesso do `FormAlunoCreate` já existente.

### 2. Gestão de setores (antes: 100% mock)
A página inteira operava sobre arrays em `useState` (usava até `prompt()`); nada persistia. O backend já tinha o CRUD completo ocioso.

- Religada à API real: `GET/POST/PATCH/DELETE /admin/setores`, `GET /admin/setores/:id/usuarios`, `POST /admin/usuarios/:usuarioId/setores`, `PATCH`/`DELETE /admin/usuarios-setores/:id`.
- Usa o **catálogo real de papéis** (`GET /admin/papeis`) como fonte de verdade nos dropdowns, contornando o descompasso entre o enum fixo do front e o `papelCatalogo` do banco (documentado na auditoria).
- Estados de loading/busy, toasts de erro e refetch após cada ação; o drawer de atribuição lista apenas contas de equipe ativas.

## Verificação
`next build --turbopack` passa; ambas as rotas (`/admin/funcionarios/novo` e `/admin/setores`) compiladas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_