### PR TITLE
fix(admin): guard na contagem de notificações + reset de senha de funcionário funcional

### DIFF
--- a/app/(dashboard)/admin/funcionarios/[id]/page.tsx
+++ b/app/(dashboard)/admin/funcionarios/[id]/page.tsx
@@ -138,7 +138,23 @@ export default function FuncionarioDetalhePage() {
   }, [id]);
 
   async function onResetSenha() {
-    showToast("Reset de senha enviado (stub).");
+    if (!func) return;
+    const email = func.emailPessoal ?? func.emailEducacional;
+    if (!email) {
+      showToast("Este funcionário não tem e-mail cadastrado para envio do link.");
+      return;
+    }
+    try {
+      const res = await apiFetch(`${API_URL}/auth/esqueci-senha`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) throw new Error(`Erro ${res.status}`);
+      showToast(`Link de redefinição de senha enviado para ${email}.`);
+    } catch (e: unknown) {
+      showToast(e instanceof Error ? e.message : "Falha ao enviar link de redefinição.");
+    }
   }
 
   async function onExcluirUsuario() {

--- a/app/(dashboard)/admin/notificacoes/page.tsx
+++ b/app/(dashboard)/admin/notificacoes/page.tsx
@@ -79,8 +79,9 @@ export default function NotificacoesAlunoPage() {
         cache: "no-store",
       });
       const data: PageResp = await res.json();
-      setNotifs(data.items ?? []);
-      setUnread(data.items.filter((n) => !n.lidaEm).length); // Recalcular as notificações não lidas
+      const items = data.items ?? [];
+      setNotifs(items);
+      setUnread(items.filter((n) => !n.lidaEm).length); // Recalcular as notificações não lidas
     } catch {
       setNotifs([]);
       setUnread(0); // Caso não haja notificações, garantir que o contador seja zero


### PR DESCRIPTION
## Resumo

Correções encontradas na varredura do frontend.

- **`/admin/notificacoes`**: a contagem de não lidas fazia `data.items.filter(...)` sem o guard `?? []` usado na linha anterior — `filter` sobre `undefined` se a resposta viesse sem `items`. Passa a usar o array já normalizado.
- **`/admin/funcionarios/[id]`**: o botão **"Reset de senha"** era um stub (`alert`). Agora dispara `POST /auth/esqueci-senha` com o e-mail do funcionário, enviando de fato o link de redefinição (o endpoint não revela existência e é rate-limited).

## Verificação
`next build --turbopack` passa; typecheck ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_