### PR TITLE
fix(chamados): roteia solicitações "outros" para a Secretaria (triagem)

### DIFF
--- a/app/(dashboard)/aluno/catalogo/outros/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/outros/page.tsx
@@ -166,6 +166,10 @@ export default function OutrosPage() {
         catalogoServicoId: "outros-solicitacao-geral",
         catalogoCategoriaId: "outros",
         catalogoCategoriaNome: "Outra solicitação",
+        // Sem serviço de catálogo, o chamado nasceria sem setor e ficaria órfão
+        // (ninguém notificado, invisível em filtros por setor). Roteia para a
+        // Secretaria, que faz a triagem e redireciona se necessário.
+        setorProvavel: "Secretaria",
         dadosAcademicos,
         camposEspecificos: { descricao: descricao.trim() },
         origem: "catalogo_wizard_aluno",


### PR DESCRIPTION
## Contexto

Investigando a dúvida "existe o tipo de chamado 'outro'?": **não existe** categoria/serviço "Outro" no banco. É uma entrada **sintética** do frontend — o card "Não encontrei o que preciso" leva ao wizard `/aluno/catalogo/outros`, que grava o chamado com `catalogoCategoriaNome: "Outra solicitação"` e ids-placeholder (os campos `catalogo*` do chamado são texto livre, não FKs).

## O bug

Diferente dos serviços normais, o wizard "outros" **não enviava `setorProvavel`** — então o chamado nascia com **`setorId = null`** e ficava órfão:
- nenhum membro de setor era notificado;
- não aparecia em filtros por setor no admin;
- só era visível na lista global → risco de nunca ser triado.

## Correção

O wizard passa a enviar `setorProvavel: "Secretaria"`. O backend (`createTicket`) casa por `nome contains "Secretaria"` e roteia o chamado para a Secretaria, que faz a triagem. (Setor de triagem escolhido pelo responsável do projeto.)

> Observação: chamados "outros" criados **antes** desta mudança continuam com `setorId` nulo — se houver algum em produção, precisa de triagem manual.

## Verificação
`next build --turbopack` passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_