### PR TITLE
feat(catalogo): card "Outros" leva ao wizard de solicitação livre

### DIFF
--- a/app/(dashboard)/aluno/catalogo/page.tsx
+++ b/app/(dashboard)/aluno/catalogo/page.tsx
@@ -48,7 +48,7 @@ function ServicoCard({ s }: { s: Servico }) {
         <div className="text-xs text-muted-foreground">ID: {s.id}</div>
         {s.ativo ? (
           <Link
-            href={`/aluno/catalogo/${s.id}`}
+            href={s.id === "outros-solicitacao-geral" ? "/aluno/catalogo/outros" : `/aluno/catalogo/${s.id}`}
             className="inline-flex items-center gap-1.5 h-9 px-3 rounded-md bg-primary text-primary-foreground text-sm transition hover:opacity-90"
           >
             <ArrowRight className="size-4" /> Preencher solicitação


### PR DESCRIPTION
## Resumo

Complemento do backend: com "outros" agora sendo um serviço real vindo de `GET /catalogo`, ele aparece como card na listagem do catálogo. O card (`id: outros-solicitacao-geral`) é roteado para `/aluno/catalogo/outros` (wizard de texto livre + triagem pela Secretaria) em vez do formulário genérico de serviço, preservando a UX de "descreva sua necessidade".

## Verificação
`next build --turbopack` passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_