### PR TITLE
fix(admin): lista de chamados do aluno no detalhe estava sempre vazia

### DIFF
--- a/app/(dashboard)/admin/alunos/[id]/page.tsx
+++ b/app/(dashboard)/admin/alunos/[id]/page.tsx
@@ -152,7 +152,10 @@ export default function PageAlunoDetalhe() {
         if (!cRes.ok) throw new Error("Falha ao buscar tickets");
         const json = await cRes.json();
         let cs: Chamado[] = [];
+        // GET /tickets responde { total, page, pageSize, items } — o array é
+        // 'items'. Sem essa chave, a lista ficava sempre vazia no detalhe.
         if (Array.isArray(json)) cs = json;
+        else if (Array.isArray(json.items)) cs = json.items;
         else if (Array.isArray(json.data)) cs = json.data;
         else if (Array.isArray(json.tickets)) cs = json.tickets;
 


### PR DESCRIPTION
## Bug

Em `/admin/alunos/[id]`, a seção de chamados do aluno buscava `GET /tickets?criadoPorId=...` e tentava ler `json.data` / `json.tickets` (ou array direto). Mas o backend responde `{ total, page, pageSize, items }` — o array está em **`items`**. Como nenhuma dessas chaves batia, `cs` ficava `[]` e **a lista de chamados do aluno aparecia sempre vazia** no detalhe, mesmo com chamados existentes.

## Correção

Passa a ler `json.items` primeiro (mantendo os fallbacks `data`/`tickets`/array por segurança).

## Verificação
`next build --turbopack` passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_