### PR TITLE
feat(ux): modais de confirmação reutilizáveis, toasts e sinalização de não salvo

### DIFF
--- a/app/(dashboard)/admin/_components/ImportAlunos.tsx
+++ b/app/(dashboard)/admin/_components/ImportAlunos.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useRef, useState } from "react";
 import { X, Info } from "lucide-react";
+import { toast } from "sonner";
 
 type ResultRow = {
   idx: number;
@@ -81,7 +82,7 @@ export default function ImportAlunos({
     const text = await file.text();
     const raw  = parseCsv(text);
     if (raw.length <= 1) {
-      alert("CSV vazio ou apenas header.");
+      toast.error("CSV vazio ou apenas cabeçalho.");
       e.target.value = "";
       return;
     }
@@ -103,7 +104,7 @@ export default function ImportAlunos({
     const iIngress = col("anossemestreingresso") >= 0 ? col("anossemestreingresso") : col("anosemestreingresso");
 
     if (iRA < 0 || iEdu < 0) {
-      alert("Cabeçalho inválido. Colunas obrigatórias: ra, emailEducacional.");
+      toast.error("Cabeçalho inválido. Colunas obrigatórias: ra, emailEducacional.");
       e.target.value = "";
       return;
     }
@@ -150,7 +151,7 @@ export default function ImportAlunos({
   }
 
   async function startImport() {
-    if (!rows.length) { alert("Selecione um CSV primeiro."); return; }
+    if (!rows.length) { toast.error("Selecione um CSV primeiro."); return; }
     setRunning(true);
     setFinished(false);
 

--- a/app/(dashboard)/admin/alunos/[id]/page.tsx
+++ b/app/(dashboard)/admin/alunos/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { apiFetch } from "../../../../../utils/api"
+import { toast } from "sonner";
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -109,7 +110,6 @@ function SectionCard({ title, icon, children }: { title: string; icon?: React.Re
   );
 }
 
-function toast(msg: string) { alert(msg); }
 
 /* ===================== Página ===================== */
 export default function PageAlunoDetalhe() {

--- a/app/(dashboard)/admin/alunos/page.tsx
+++ b/app/(dashboard)/admin/alunos/page.tsx
@@ -16,6 +16,8 @@ import {
 
 import FormAlunoCreate from "./../_components/FormAlunoCreate";
 import ImportAlunos from "./../_components/ImportAlunos";
+import ConfirmDialog from "../../../components/ui/ConfirmDialog";
+import { toast } from "sonner";
 
 import { cx } from '../../../../utils/cx'
 
@@ -78,6 +80,7 @@ export default function AdminAlunosPage() {
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const [page, setPage] = useState(1);
   const perPage = 20;
@@ -249,15 +252,7 @@ export default function AdminAlunosPage() {
     });
   }
 
-  async function handleDeleteSelected() {
-    if (!hasSelected) return;
-    const count = selectedIds.size;
-    const confirmMsg =
-      count === 1
-        ? "Tem certeza que deseja excluir este aluno?"
-        : `Tem certeza que deseja excluir ${count} alunos?`;
-    if (!window.confirm(confirmMsg)) return;
-
+  async function doDeleteSelected() {
     try {
       setDeleting(true);
       const token =
@@ -274,8 +269,11 @@ export default function AdminAlunosPage() {
       const failed = results.filter(
         (r) => r.status === "rejected" || (r.status === "fulfilled" && !r.value.ok),
       );
+      const okCount = selectedIds.size - failed.length;
       if (failed.length) {
-        alert(`Alguns registros não puderam ser excluídos (${failed.length}/${selectedIds.size}).`);
+        toast.warning(`${okCount} excluído(s), ${failed.length} com erro.`);
+      } else {
+        toast.success(okCount === 1 ? "Aluno excluído." : `${okCount} alunos excluídos.`);
       }
 
       setSelectedIds(new Set());
@@ -283,7 +281,8 @@ export default function AdminAlunosPage() {
       fetchAlunos();
     } catch (e) {
       console.error(e);
-      alert("Erro ao excluir alunos selecionados.");
+      toast.error("Erro ao excluir alunos selecionados.");
+      throw e;
     } finally {
       setDeleting(false);
     }
@@ -360,7 +359,7 @@ export default function AdminAlunosPage() {
                 </button>
                 <button
                   type="button"
-                  onClick={handleDeleteSelected}
+                  onClick={() => hasSelected && setConfirmDelete(true)}
                   disabled={!hasSelected || deleting}
                   className={cx(
                     "inline-flex items-center gap-2 h-10 px-3 rounded-lg border text-sm",
@@ -524,6 +523,16 @@ export default function AdminAlunosPage() {
           </div>
         </>
       )}
+
+      <ConfirmDialog
+        open={confirmDelete}
+        title={selectedIds.size === 1 ? "Excluir aluno?" : `Excluir ${selectedIds.size} alunos?`}
+        description="Os registros serão removidos (soft delete). Você pode confirmar para prosseguir."
+        confirmLabel="Excluir"
+        variant="danger"
+        onConfirm={doDeleteSelected}
+        onClose={() => setConfirmDelete(false)}
+      />
     </div>
   );
 }

--- a/app/(dashboard)/admin/comunicacoes/page.tsx
+++ b/app/(dashboard)/admin/comunicacoes/page.tsx
@@ -8,6 +8,7 @@ import {
 import { toast } from "sonner";
 import { cx } from '../../../../utils/cx'
 import { apiFetch } from "../../../../utils/api";
+import ConfirmDialog from "../../../components/ui/ConfirmDialog";
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
 
@@ -187,7 +188,21 @@ export default function ComunicacoesPage() {
   const [currentId, setCurrentId] = useState<string>(DEFAULT_TEMPLATES[0]?.id ?? "");
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
+  const [dirty, setDirty] = useState<Set<string>>(new Set());
+  const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
+  // Versão "limpa" (última salva/carregada) de cada template, para descartar edições.
+  const baselineRef = useRef<Map<string, Template>>(new Map(DEFAULT_TEMPLATES.map((t) => [t.id, t])));
+
+  const markClean = (id: string, snapshot: Template) => {
+    baselineRef.current.set(id, snapshot);
+    setDirty((prev) => {
+      if (!prev.has(id)) return prev;
+      const n = new Set(prev);
+      n.delete(id);
+      return n;
+    });
+  };
 
   /* Carrega os templates persistidos e mescla sobre os defaults (por chave). */
   useEffect(() => {
@@ -201,7 +216,7 @@ export default function ComunicacoesPage() {
           prev.map((t) => {
             const salvo = porChave.get(t.key);
             if (!salvo) return t;
-            return {
+            const merged = {
               ...t,
               nome: salvo.nome ?? t.nome,
               descricao: salvo.descricao ?? t.descricao,
@@ -210,11 +225,45 @@ export default function ComunicacoesPage() {
               corpo: salvo.corpo ?? t.corpo,
               variaveis: (salvo.variaveis as string[] | undefined) ?? t.variaveis,
             };
+            baselineRef.current.set(t.id, merged); // baseline = versão carregada
+            return merged;
           }),
         );
       })
       .catch(() => {});
   }, []);
+
+  // Avisa ao fechar/recarregar a aba com edições pendentes.
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (dirty.size === 0) return;
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [dirty]);
+
+  // Troca de template pedindo confirmação se houver edições não salvas.
+  function requestSwitch(id: string) {
+    if (id === currentId) return;
+    if (dirty.has(currentId)) { setPendingSwitch(id); return; }
+    setCurrentId(id);
+  }
+
+  function discardAndSwitch() {
+    const base = baselineRef.current.get(currentId);
+    if (base) {
+      setTemplates((prev) => prev.map((t) => (t.id === currentId ? base : t)));
+    }
+    setDirty((prev) => {
+      const n = new Set(prev);
+      n.delete(currentId);
+      return n;
+    });
+    if (pendingSwitch) setCurrentId(pendingSwitch);
+    setPendingSwitch(null);
+  }
 
   async function persistir(t: Template) {
     const res = await apiFetch(`${API_URL}/admin/comunicacoes/${encodeURIComponent(t.key)}`, {
@@ -240,6 +289,7 @@ export default function ComunicacoesPage() {
     setSaving(true);
     try {
       await persistir(current);
+      markClean(current.id, current); // vira a nova baseline; limpa o "sujo"
       toast.success("Template salvo.");
     } catch (e: any) {
       toast.error(e?.message ?? "Falha ao salvar template");
@@ -268,6 +318,7 @@ export default function ComunicacoesPage() {
     setTemplates((prev) => prev.map(t => t.id === id ? atualizado : t));
     try {
       await persistir(atualizado);
+      baselineRef.current.set(id, atualizado); // mantém a baseline em sincronia
     } catch (e: any) {
       // Reverte em caso de falha na persistência.
       setTemplates((prev) => prev.map(t => t.id === id ? alvo : t));
@@ -277,6 +328,7 @@ export default function ComunicacoesPage() {
 
   function updateField<K extends keyof Template>(field: K, value: Template[K]) {
     setTemplates((prev) => prev.map(t => t.id === currentId ? { ...t, [field]: value } : t));
+    setDirty((prev) => (prev.has(currentId) ? prev : new Set(prev).add(currentId)));
   }
 
   async function sendTest() {
@@ -350,11 +402,14 @@ export default function ComunicacoesPage() {
                     "w-full text-left rounded-lg px-3 py-2 transition flex items-center justify-between",
                     currentId === t.id ? "bg-primary text-primary-foreground shadow-sm" : "hover:bg-[var(--muted)]/70"
                   )}
-                  onClick={() => setCurrentId(t.id)}
+                  onClick={() => requestSwitch(t.id)}
                 >
                   <span className="flex items-center gap-2">
                     <Mail className="size-4 opacity-80" />
                     <span className="font-medium">{t.nome}</span>
+                    {dirty.has(t.id) && (
+                      <span className="size-1.5 rounded-full bg-amber-500" title="Alterações não salvas" />
+                    )}
                   </span>
                   <span
                     className={cx(
@@ -456,10 +511,16 @@ export default function ComunicacoesPage() {
                 <button
                   className="inline-flex items-center gap-2 h-10 px-3 rounded-lg bg-primary text-primary-foreground text-sm hover:brightness-95 disabled:opacity-60"
                   onClick={salvarTemplate}
-                  disabled={saving}
+                  disabled={saving || !dirty.has(current.id)}
                 >
                   <Save className="size-4" /> {saving ? "Salvando…" : "Salvar"}
                 </button>
+                {dirty.has(current.id) && (
+                  <span className="inline-flex items-center gap-1.5 text-xs text-amber-600">
+                    <span className="size-1.5 rounded-full bg-amber-500" />
+                    Alterações não salvas
+                  </span>
+                )}
                 <button
                   className="inline-flex items-center gap-2 h-10 px-3 rounded-lg border border-[var(--border)] bg-background text-sm hover:bg-[var(--muted)] disabled:opacity-60"
                   onClick={sendTest}
@@ -504,6 +565,17 @@ export default function ComunicacoesPage() {
           </div>
         )}
       </section>
+
+      <ConfirmDialog
+        open={pendingSwitch !== null}
+        title="Descartar alterações não salvas?"
+        description="Você editou este template mas não salvou. Trocar de template vai descartar as alterações."
+        confirmLabel="Descartar"
+        cancelLabel="Continuar editando"
+        variant="danger"
+        onConfirm={discardAndSwitch}
+        onClose={() => setPendingSwitch(null)}
+      />
     </div>
   );
 }

--- a/app/(dashboard)/admin/funcionarios/[id]/page.tsx
+++ b/app/(dashboard)/admin/funcionarios/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { apiFetch } from "../../../../../utils/api";
+import { toast } from "sonner";
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -67,7 +68,7 @@ function StatusPill({ ativo }: { ativo: boolean }) {
   );
 }
 
-function showToast(msg: string) { alert(msg); }
+function showToast(msg: string) { toast(msg); }
 
 export default function FuncionarioDetalhePage() {
   const { id } = useParams<{ id: string }>();

--- a/app/(dashboard)/admin/setores/page.tsx
+++ b/app/(dashboard)/admin/setores/page.tsx
@@ -9,8 +9,11 @@ import {
 import { toast } from "sonner";
 import { cx } from '../../../../utils/cx'
 import { apiFetch } from "../../../../utils/api";
+import ConfirmDialog, { type ConfirmDialogProps } from "../../../components/ui/ConfirmDialog";
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+
+type DialogConfig = Omit<ConfirmDialogProps, "open" | "onClose">;
 
 /* ===================== Tipos alinhados ao schema ===================== */
 type PapelCatalogo = {
@@ -79,6 +82,7 @@ export default function SetoresPage() {
   const currentSetor = setores.find(s => s.id === currentSetorId) ?? null;
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [dlg, setDlg] = useState<DialogConfig | null>(null);
 
   /* ── Carga inicial: setores, papéis e funcionários ── */
   const carregarSetores = useCallback(async (selecionar?: string) => {
@@ -145,9 +149,8 @@ export default function SetoresPage() {
     [membros],
   );
 
-  /* ── CRUD de setores ── */
-  async function criarSetor() {
-    const nome = prompt("Nome do novo setor:")?.trim();
+  /* ── CRUD de setores (ação separada da confirmação/prompt via modal) ── */
+  async function doCriarSetor(nome?: string) {
     if (!nome) return;
     setBusy(true);
     try {
@@ -162,15 +165,14 @@ export default function SetoresPage() {
       await carregarSetores(novo?.id);
     } catch (e: any) {
       toast.error(e?.message ?? "Erro ao criar setor");
+      throw e;
     } finally {
       setBusy(false);
     }
   }
 
-  async function renomearSetor() {
-    if (!currentSetor) return;
-    const nome = prompt("Novo nome do setor:", currentSetor.nome)?.trim();
-    if (!nome || nome === currentSetor.nome) return;
+  async function doRenomearSetor(nome?: string) {
+    if (!currentSetor || !nome || nome === currentSetor.nome) return;
     setBusy(true);
     try {
       const res = await apiFetch(`${API_URL}/admin/setores/${currentSetor.id}`, {
@@ -183,18 +185,14 @@ export default function SetoresPage() {
       await carregarSetores(currentSetor.id);
     } catch (e: any) {
       toast.error(e?.message ?? "Erro ao renomear setor");
+      throw e;
     } finally {
       setBusy(false);
     }
   }
 
-  async function removerSetor() {
+  async function doRemoverSetor() {
     if (!currentSetor) return;
-    const temMembros = membros.length > 0;
-    const msg = temMembros
-      ? "Este setor possui membros. Remover mesmo assim? Os vínculos serão excluídos."
-      : `Remover o setor "${currentSetor.nome}"?`;
-    if (!confirm(msg)) return;
     setBusy(true);
     try {
       const res = await apiFetch(`${API_URL}/admin/setores/${currentSetor.id}`, { method: "DELETE" });
@@ -203,9 +201,55 @@ export default function SetoresPage() {
       await carregarSetores();
     } catch (e: any) {
       toast.error(e?.message ?? "Erro ao remover setor");
+      throw e;
     } finally {
       setBusy(false);
     }
+  }
+
+  /* ── Gatilhos que abrem o modal de confirmação/prompt ── */
+  function criarSetor() {
+    setDlg({
+      title: "Novo setor",
+      description: "Informe o nome do novo setor.",
+      confirmLabel: "Criar",
+      input: { label: "Nome do setor", placeholder: "Ex.: Secretaria", required: true },
+      onConfirm: (nome) => doCriarSetor(nome),
+    });
+  }
+
+  function renomearSetor() {
+    if (!currentSetor) return;
+    setDlg({
+      title: "Renomear setor",
+      confirmLabel: "Salvar",
+      input: { label: "Novo nome", defaultValue: currentSetor.nome, required: true },
+      onConfirm: (nome) => doRenomearSetor(nome),
+    });
+  }
+
+  function removerSetor() {
+    if (!currentSetor) return;
+    const temMembros = membros.length > 0;
+    setDlg({
+      title: `Remover "${currentSetor.nome}"?`,
+      description: temMembros
+        ? "Este setor possui membros — os vínculos serão excluídos. Esta ação não pode ser desfeita."
+        : "Esta ação não pode ser desfeita.",
+      confirmLabel: "Remover",
+      variant: "danger",
+      onConfirm: () => doRemoverSetor(),
+    });
+  }
+
+  function removerMembro(usuarioSetorId: string) {
+    setDlg({
+      title: "Remover do setor?",
+      description: "O funcionário perde o vínculo com este setor (a conta não é excluída).",
+      confirmLabel: "Remover",
+      variant: "danger",
+      onConfirm: () => doRemoverMembro(usuarioSetorId),
+    });
   }
 
   /* ── Membros ── */
@@ -226,8 +270,7 @@ export default function SetoresPage() {
     }
   }
 
-  async function removerMembro(usuarioSetorId: string) {
-    if (!confirm("Remover este funcionário do setor?")) return;
+  async function doRemoverMembro(usuarioSetorId: string) {
     setBusy(true);
     try {
       const res = await apiFetch(`${API_URL}/admin/usuarios-setores/${usuarioSetorId}`, { method: "DELETE" });
@@ -236,6 +279,7 @@ export default function SetoresPage() {
       await carregarMembros(currentSetorId);
     } catch (e: any) {
       toast.error(e?.message ?? "Erro ao remover membro");
+      throw e;
     } finally {
       setBusy(false);
     }
@@ -484,6 +528,8 @@ export default function SetoresPage() {
           onAssign={atribuirUsuariosAoSetor}
         />
       )}
+
+      {dlg && <ConfirmDialog open {...dlg} onClose={() => setDlg(null)} />}
     </div>
   );
 }

--- a/app/components/ui/ConfirmDialog.tsx
+++ b/app/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import Button from "./Button";
+
+type Variant = "default" | "danger";
+
+export type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: Variant;
+  /** Modo prompt: quando definido, mostra um input e passa o valor ao onConfirm. */
+  input?: {
+    label?: string;
+    placeholder?: string;
+    defaultValue?: string;
+    required?: boolean;
+  };
+  /** Pode ser async; enquanto resolve, o botão mostra loading. Lançar erro mantém o modal aberto. */
+  onConfirm: (value?: string) => void | Promise<void>;
+  onClose: () => void;
+};
+
+/**
+ * Modal de confirmação reutilizável — substitui window.confirm/prompt nativos.
+ * Suporta variante "danger" e um modo prompt (input de texto).
+ */
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirmar",
+  cancelLabel = "Cancelar",
+  variant = "default",
+  input,
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  const [value, setValue] = useState(input?.defaultValue ?? "");
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reinicia o valor a cada abertura e move o foco para o campo (modo prompt).
+  useEffect(() => {
+    if (!open) return;
+    setValue(input?.defaultValue ?? "");
+    if (input) {
+      const t = setTimeout(() => inputRef.current?.focus(), 30);
+      return () => clearTimeout(t);
+    }
+  }, [open, input?.defaultValue]);
+
+  // Fecha no Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !loading) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, loading, onClose]);
+
+  if (!open) return null;
+
+  const invalid = !!input?.required && value.trim().length === 0;
+
+  async function handleConfirm() {
+    if (invalid || loading) return;
+    setLoading(true);
+    try {
+      await onConfirm(input ? value.trim() : undefined);
+      onClose(); // sucesso fecha; em erro o onConfirm deve lançar para manter aberto
+    } catch {
+      setLoading(false); // mantém o modal aberto para nova tentativa
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60]" role="dialog" aria-modal="true" aria-label={title}>
+      <div
+        className="absolute inset-0 bg-black/40 motion-safe:animate-[fadeIn_120ms_ease-out]"
+        onClick={() => !loading && onClose()}
+      />
+      <div className="absolute left-1/2 top-1/2 w-[92%] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-[var(--border)] bg-background p-5 shadow-xl motion-safe:animate-[popIn_140ms_ease-out]">
+        <div className="flex items-start gap-3">
+          {variant === "danger" && (
+            <span className="mt-0.5 inline-grid size-9 shrink-0 place-items-center rounded-full bg-destructive/10 text-destructive">
+              <AlertTriangle className="size-5" />
+            </span>
+          )}
+          <div className="min-w-0 flex-1">
+            <h2 className="font-grotesk text-lg font-semibold leading-tight">{title}</h2>
+            {description && (
+              <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+            )}
+          </div>
+        </div>
+
+        {input && (
+          <div className="mt-4">
+            {input.label && (
+              <label className="mb-1 block text-sm text-muted-foreground">{input.label}</label>
+            )}
+            <input
+              ref={inputRef}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={input.placeholder}
+              onKeyDown={(e) => { if (e.key === "Enter") handleConfirm(); }}
+              className="w-full h-10 rounded-lg border border-[var(--border)] bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+            />
+          </div>
+        )}
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={loading}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={variant === "danger" ? "destructive" : "primary"}
+            onClick={handleConfirm}
+            loading={loading}
+            disabled={invalid}
+            autoFocus={!input}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+
+      <style jsx global>{`
+        @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
+        @keyframes popIn { from { opacity: 0; transform: translate(-50%, -48%) scale(0.98) } to { opacity: 1; transform: translate(-50%, -50%) scale(1) } }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumo

Primeira leva da rodada de UX/qualidade.

### Componente reutilizável `ui/ConfirmDialog`
Modal de confirmação acessível (Escape, `role=dialog`, foco, transições `motion-safe`), com variante **danger** e **modo prompt** (input). Contrato: sucesso fecha sozinho; erro mantém aberto para nova tentativa. Substitui os diálogos nativos do browser.

### Diálogos nativos → modal/toast
- **`/admin/setores`**: `prompt()`/`confirm()` nativos → `ConfirmDialog` (criar/renomear via input; remover setor/membro em danger).
- **`/admin/alunos`**: exclusão em massa passa a confirmar via `ConfirmDialog`; feedback por toast (parcial/erro) no lugar de `alert()`.
- **alert()-como-toast → `sonner`**: `alunos/[id]`, `funcionarios/[id]` e os avisos de validação do `ImportAlunos`.

### Alterações não salvas (editor de comunicações)
- Rastreia edições por template com baseline (permite **descarte real**).
- Badge "Alterações não salvas" + ponto âmbar na lista; **Salvar** desabilitado sem mudanças.
- Trocar de template com edições pendentes abre confirmação ("Descartar" / "Continuar editando").
- `beforeunload` avisa ao fechar/recarregar com pendências.

## Verificação
`next build --turbopack` passa; typecheck ok.

## Próxima leva (não incluída aqui)
Skeletons/transições nas listas, revisão de copy restante e os `alert/confirm` de `configuracoes`/`funcionarios` (upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_