### PR TITLE
fix(erros): mensagens de erro corretas nos forms + envio de mensagem robusto

### DIFF
--- a/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
+++ b/app/(dashboard)/admin/_components/FormAlunoCreate.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { apiFetch } from "../../../../utils/api";
+import { apiFetch, extractApiError } from "../../../../utils/api";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -137,16 +137,7 @@ export default function FormAlunoCreate({ onSuccess, onCancel }: Props) {
       });
 
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        try {
-          const json = JSON.parse(text);
-          if (json?.issues?.length) {
-            throw new Error(json.issues.map((i: any) => `${i.path}: ${i.message}`).join(" | "));
-          }
-          throw new Error(json?.message || `Falha ao criar aluno (${res.status})`);
-        } catch {
-          throw new Error(text || `Falha ao criar aluno (${res.status})`);
-        }
+        throw new Error(await extractApiError(res, `Falha ao criar aluno (${res.status})`));
       }
 
       const created = await res.json();

--- a/app/(dashboard)/admin/_components/FormAlunoEdit.tsx
+++ b/app/(dashboard)/admin/_components/FormAlunoEdit.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { apiFetch } from "../../../../utils/api";
+import { apiFetch, extractApiError } from "../../../../utils/api";
 import { useEffect, useMemo, useState } from "react";
 import { Loader2, X } from "lucide-react";
 
@@ -127,13 +127,7 @@ export default function FormAlunoEdit({ aluno, onClose, onSaved }: Props) {
       });
 
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        try {
-          const json = JSON.parse(text);
-          throw new Error(json?.message || `Falha ao atualizar (${res.status})`);
-        } catch {
-          throw new Error(text || `Falha ao atualizar (${res.status})`);
-        }
+        throw new Error(await extractApiError(res, `Falha ao atualizar (${res.status})`));
       }
 
       const updated = await res.json();

--- a/app/(dashboard)/admin/_components/FormFuncionarioCreate.tsx
+++ b/app/(dashboard)/admin/_components/FormFuncionarioCreate.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { apiFetch } from "../../../../utils/api";
+import { apiFetch, extractApiError } from "../../../../utils/api";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -95,16 +95,7 @@ export default function FormFuncionarioCreate({ onSuccess, onCancel }: Props) {
       });
 
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        try {
-          const json = JSON.parse(text);
-          if (json?.issues?.length) {
-            throw new Error(json.issues.map((i: any) => `${i.path}: ${i.message}`).join(" | "));
-          }
-          throw new Error(json?.message || json?.error || `Falha ao criar funcionário (${res.status})`);
-        } catch {
-          throw new Error(text || `Falha ao criar funcionário (${res.status})`);
-        }
+        throw new Error(await extractApiError(res, `Falha ao criar funcionário (${res.status})`));
       }
 
       const created = await res.json();

--- a/app/(dashboard)/admin/mensagens/page.tsx
+++ b/app/(dashboard)/admin/mensagens/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { apiFetch } from "../../../../utils/api";
+import { apiFetch, extractApiError } from "../../../../utils/api";
 import { toast } from "sonner";
 import Link from "next/link";
 import {
@@ -193,6 +193,8 @@ export default function AdminMensagensPage() {
         method: "POST",
         body: JSON.stringify({ conteudo: v }),
       });
+      // Sem checar res.ok, um erro (404/500) vira "mensagem" corrompida no chat.
+      if (!res.ok) throw new Error(await extractApiError(res, "Falha ao enviar mensagem"));
       const saved = await res.json();
       // troca o otimista pelo salvo
       setMessages((prev) =>
@@ -200,10 +202,11 @@ export default function AdminMensagensPage() {
       );
       // atualiza lista
       fetchConversas().catch(() => {});
-    } catch {
+    } catch (e: unknown) {
       // reverte em caso de erro
       setMessages((prev) => prev.filter((m) => m.id !== tempId));
       setText(v);
+      toast.error(e instanceof Error ? e.message : "Falha ao enviar mensagem.");
     } finally {
       setSending(false);
     }

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -101,6 +101,26 @@ export async function apiFetch(input: RequestInfo, init: RequestInit = {}) {
 }
 
 /**
+ * Extrai uma mensagem de erro amigável do corpo de uma resposta não-ok.
+ * Lê o corpo UMA vez e cobre os formatos do backend: { issues: [{path,message}] }
+ * (validação Zod), { error } e { message }. Cai para o texto cru ou o fallback.
+ */
+export async function extractApiError(res: Response, fallback?: string): Promise<string> {
+  const base = fallback ?? `Erro ${res.status}`;
+  const text = await res.text().catch(() => "");
+  if (!text) return base;
+  try {
+    const json = JSON.parse(text);
+    if (Array.isArray(json?.issues) && json.issues.length) {
+      return json.issues.map((i: any) => `${i.path}: ${i.message}`).join(" | ");
+    }
+    return json?.error || json?.message || base;
+  } catch {
+    return text;
+  }
+}
+
+/**
  * Faz download autenticado de um anexo.
  * Cria um URL temporário a partir do blob e dispara o download no browser.
  */


### PR DESCRIPTION
## Bugs de tratativa de erro

### 1. Mensagem de erro descartada nos formulários
`FormAlunoCreate`, `FormFuncionarioCreate` e `FormAlunoEdit` usavam:
```ts
try {
  const json = JSON.parse(text);
  throw new Error(json?.message || ...);   // ← este throw
} catch {
  throw new Error(text || ...);            // ← é capturado aqui
}
```
O `throw` dentro do `try` era **imediatamente capturado pelo `catch` local**, descartando a mensagem parseada — o usuário via o **JSON cru** como erro. Pior: liam `json.message`, mas o backend responde `json.error` / `json.issues` (validação Zod), então a mensagem certa nunca aparecia.

**Correção:** novo helper reutilizável `extractApiError(res, fallback)` em `utils/api.ts` — lê o corpo uma vez, cobre `issues`/`error`/`message` e cai para o texto/fallback. Os três forms passam a fazer um único `throw new Error(await extractApiError(...))`.

### 2. Envio de mensagem no chat do admin corrompia a lista
`/admin/mensagens` fazia `res.json()` **sem checar `res.ok`**. Numa falha (404/500), a resposta de erro substituía a mensagem otimista por um objeto sem `conteudo`/`id`, corrompendo o chat silenciosamente. Agora checa `ok`, reverte a mensagem otimista e mostra um toast com a mensagem real do backend.

## Verificação
`next build --turbopack` passa; typecheck ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_