### PR TITLE
feat(mock): reset de senha do aluno funcional + configurações vira política read-only

### DIFF
--- a/app/(dashboard)/admin/alunos/[id]/page.tsx
+++ b/app/(dashboard)/admin/alunos/[id]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { apiFetch } from "../../../../../utils/api"
+import { apiFetch, extractApiError } from "../../../../../utils/api"
 import { toast } from "sonner";
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
@@ -201,8 +201,24 @@ export default function PageAlunoDetalhe() {
     }
   }
 
-  function onResetSenha() {
-    toast("Reset de senha enviado (stub).");
+  async function onResetSenha() {
+    if (!aluno) return;
+    const email = aluno.emailPessoal || aluno.emailEducacional;
+    if (!email) {
+      toast.error("Este aluno não tem e-mail cadastrado para envio do link.");
+      return;
+    }
+    try {
+      const res = await apiFetch(`${API_URL}/auth/esqueci-senha`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) throw new Error(await extractApiError(res, `Erro ${res.status}`));
+      toast.success(`Link de redefinição de senha enviado para ${email}.`);
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Falha ao enviar link de redefinição.");
+    }
   }
 
   if (loading) {

--- a/app/(dashboard)/admin/configuracoes/page.tsx
+++ b/app/(dashboard)/admin/configuracoes/page.tsx
@@ -1,54 +1,13 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import { Check, X, Shield, Download, Upload, RotateCcw, Info } from "lucide-react";
-import { cx } from '../../../../utils/cx'
+import { useMemo, useState } from "react";
+import { Check, X, Shield, Info, Lock } from "lucide-react";
 
-/* ===================== PAPÉIS (alinhados ao enum Papel) ===================== */
+/* ===================== Papéis (enum Papel do backend) ===================== */
 type Role = "USUARIO" | "BACKOFFICE" | "TECNICO" | "ADMINISTRADOR";
 
-/* ===================== Recursos/Ações ===================== */
-type ResourceKey =
-  | "CHAMADO_CRIAR"
-  | "CHAMADO_VER"
-  | "CHAMADO_COMENTAR"
-  | "CHAMADO_ANEXAR"
-  | "CHAMADO_ALTERAR_STATUS"
-  | "CHAMADO_ATRIBUIR_RESP"
-  | "CHAMADO_REABRIR"
-  | "CHAMADO_ENCERRAR"
-  | "CHAMADO_HISTORICO_VER"
-  | "CATALOGO_LISTAR"
-  | "CATALOGO_EDITAR"
-  | "CATEGORIAS_SETORES_EDITAR"
-  | "USUARIOS_LISTAR"
-  | "USUARIOS_EDITAR"
-  | "VINCULAR_USUARIO_SETOR"
-  | "AUDITORIA_VISUALIZAR"
-  | "RELATORIOS"
-  | "ADMIN_CONFIG";
+const ROLES: Role[] = ["USUARIO", "BACKOFFICE", "TECNICO", "ADMINISTRADOR"];
 
-/* Escopos possíveis por ação (não é todo mundo que usa todos) */
-type Scope =
-  | "sempre"                  // sempre pode (sem escopo)
-  | "proprios"
-  | "todos"
-  | "organizacao"
-  | "setores"
-  | "atribuido_e_setor"
-  | "para_si_ou_time"
-  | "qualquer"
-  | "operacional"
-  | "opcional"
-  | "limitado"
-  | "gerencial"
-  | "resolvido_para_encerrado"; // caso especial do aluno encerrar só de RESOLVIDO→ENCERRADO
-
-type Cell = { allow: boolean; scope?: Scope };
-
-type Matrix = Record<ResourceKey, Record<Role, Cell>>;
-
-/* ===================== Rótulos ===================== */
 const ROLE_LABEL: Record<Role, string> = {
   USUARIO: "Usuário (Aluno)",
   BACKOFFICE: "Backoffice",
@@ -56,404 +15,258 @@ const ROLE_LABEL: Record<Role, string> = {
   ADMINISTRADOR: "Administrador",
 };
 
-const RESOURCE_LABEL: Record<ResourceKey, string> = {
-  CHAMADO_CRIAR: "Chamado — criar",
-  CHAMADO_VER: "Chamado — ver",
-  CHAMADO_COMENTAR: "Chamado — comentar/mensagens",
-  CHAMADO_ANEXAR: "Chamado — anexar arquivos",
-  CHAMADO_ALTERAR_STATUS: "Chamado — alterar status",
-  CHAMADO_ATRIBUIR_RESP: "Chamado — atribuir responsável",
-  CHAMADO_REABRIR: "Chamado — reabrir",
-  CHAMADO_ENCERRAR: "Chamado — encerrar",
-  CHAMADO_HISTORICO_VER: "Chamado — ver histórico",
-  CATALOGO_LISTAR: "Catálogo/Serviços — listar",
-  CATALOGO_EDITAR: "Catálogo/Serviços — criar/editar",
-  CATEGORIAS_SETORES_EDITAR: "Categorias/Setores — criar/editar",
-  USUARIOS_LISTAR: "Usuários — listar",
-  USUARIOS_EDITAR: "Usuários — criar/editar",
-  VINCULAR_USUARIO_SETOR: "Vincular usuário a setor",
-  AUDITORIA_VISUALIZAR: "Auditoria — visualizar",
-  RELATORIOS: "Relatórios",
-  ADMIN_CONFIG: "Administração — configurações gerais",
+/* ===================== Recursos ===================== */
+type ResourceKey =
+  | "CHAMADO_CRIAR"
+  | "CHAMADO_VER"
+  | "CHAMADO_COMENTAR"
+  | "CHAMADO_ANEXAR"
+  | "CHAMADO_EDITAR"
+  | "CHAMADO_REMOVER"
+  | "CATALOGO_LISTAR"
+  | "USUARIOS_LISTAR"
+  | "USUARIOS_CRIAR"
+  | "USUARIOS_EDITAR"
+  | "USUARIOS_REMOVER"
+  | "SETORES_GERENCIAR"
+  | "VINCULAR_USUARIO_SETOR"
+  | "PAPEIS_GERENCIAR"
+  | "COMUNICACOES_GERENCIAR"
+  | "AUDITORIA_VISUALIZAR"
+  | "RELATORIOS";
+
+type Rota = { metodo: string; caminho: string };
+
+type LinhaRecurso = {
+  label: string;
+  rota: Rota;
+  perfis: Partial<Record<Role, "todos" | "proprios">>; // ausente = negado
 };
 
-const SCOPE_LABEL: Record<Scope, string> = {
-  sempre: "(sempre)",
-  proprios: "próprios",
-  todos: "todos",
-  organizacao: "todos da organização",
-  setores: "do(s) setor(es)",
-  atribuido_e_setor: "atribuídos + setor(es)",
-  para_si_ou_time: "(para si/time)",
-  qualquer: "(qualquer)",
-  operacional: "(operacional)",
-  opcional: "(opcional)",
-  limitado: "(limitado)",
-  gerencial: "(gerencial)",
-  resolvido_para_encerrado: "próprios (RESOLVIDO → ENCERRADO)",
-};
-
-/* ===================== Matriz Padrão (a partir da planilha) ===================== */
-function defaultMatrix(): Matrix {
-  return {
-    CHAMADO_CRIAR: {
-      USUARIO: { allow: true, scope: "sempre" },
-      BACKOFFICE: { allow: true, scope: "sempre" },
-      TECNICO: { allow: true, scope: "setores" },
-      ADMINISTRADOR: { allow: true, scope: "todos" },
-    },
-    CHAMADO_VER: {
-      USUARIO: { allow: true, scope: "proprios" },
-      BACKOFFICE: { allow: true, scope: "organizacao" },
-      TECNICO: { allow: true, scope: "atribuido_e_setor" },
-      ADMINISTRADOR: { allow: true, scope: "todos" },
-    },
-    CHAMADO_COMENTAR: {
-      USUARIO: { allow: true, scope: "proprios" },
-      BACKOFFICE: { allow: true, scope: "todos" },
-      TECNICO: { allow: true, scope: "atribuido_e_setor" },
-      ADMINISTRADOR: { allow: true, scope: "todos" },
-    },
-    CHAMADO_ANEXAR: {
-      USUARIO: { allow: true, scope: "proprios" },
-      BACKOFFICE: { allow: true, scope: "todos" },
-      TECNICO: { allow: true, scope: "atribuido_e_setor" },
-      ADMINISTRADOR: { allow: true, scope: "todos" },
-    },
-    CHAMADO_ALTERAR_STATUS: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: true, scope: "todos" },
-      TECNICO: { allow: true, scope: "para_si_ou_time" },
-      ADMINISTRADOR: { allow: true, scope: "qualquer" },
-    },
-    CHAMADO_ATRIBUIR_RESP: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: true },
-      TECNICO: { allow: false },
-      ADMINISTRADOR: { allow: true },
-    },
-    CHAMADO_REABRIR: {
-      USUARIO: { allow: true, scope: "proprios" },
-      BACKOFFICE: { allow: true },
-      TECNICO: { allow: false },
-      ADMINISTRADOR: { allow: true },
-    },
-    CHAMADO_ENCERRAR: {
-      USUARIO: { allow: true, scope: "resolvido_para_encerrado" },
-      BACKOFFICE: { allow: false },
-      TECNICO: { allow: true },
-      ADMINISTRADOR: { allow: true },
-    },
-    CHAMADO_HISTORICO_VER: {
-      USUARIO: { allow: true, scope: "proprios" },
-      BACKOFFICE: { allow: true, scope: "todos" },
-      TECNICO: { allow: true, scope: "setores" },
-      ADMINISTRADOR: { allow: true, scope: "todos" },
-    },
-    CATALOGO_LISTAR: {
-      USUARIO: { allow: true },
-      BACKOFFICE: { allow: true },
-      TECNICO: { allow: true },
-      ADMINISTRADOR: { allow: true },
-    },
-    CATALOGO_EDITAR: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: true, scope: "operacional" },
-      TECNICO: { allow: true, scope: "setores" },
-      ADMINISTRADOR: { allow: true, scope: "todos" },
-    },
-    CATEGORIAS_SETORES_EDITAR: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: false, scope: "opcional" },
-      TECNICO: { allow: false },
-      ADMINISTRADOR: { allow: true },
-    },
-    USUARIOS_LISTAR: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: true, scope: "limitado" },
-      TECNICO: { allow: false },
-      ADMINISTRADOR: { allow: true },
-    },
-    USUARIOS_EDITAR: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: false },
-      TECNICO: { allow: false },
-      ADMINISTRADOR: { allow: true },
-    },
-    VINCULAR_USUARIO_SETOR: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: false },
-      TECNICO: { allow: true, scope: "para_si_ou_time" }, // auto/time
-      ADMINISTRADOR: { allow: true },
-    },
-    AUDITORIA_VISUALIZAR: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: true, scope: "operacional" },
-      TECNICO: { allow: true, scope: "setores" },
-      ADMINISTRADOR: { allow: true, scope: "gerencial" },
-    },
-    RELATORIOS: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: true },
-      TECNICO: { allow: true, scope: "setores" },
-      ADMINISTRADOR: { allow: true },
-    },
-    ADMIN_CONFIG: {
-      USUARIO: { allow: false },
-      BACKOFFICE: { allow: false },
-      TECNICO: { allow: false },
-      ADMINISTRADOR: { allow: true },
-    },
-  };
-}
-
-/* Escopos disponíveis por linha/coluna (para limitar dropdown) */
-const ROW_ROLE_SCOPES: Partial<Record<ResourceKey, Partial<Record<Role, Scope[]>>>> = {
+/**
+ * Política REAL aplicada pelo backend (por rota). Derivada dos preHandlers
+ * `authenticate` + `authorize([...])` e das verificações de posse do aluno.
+ * Esta tela é somente-leitura: reflete o que o servidor impõe hoje, não é
+ * configurável (a autorização está no código, por rota).
+ */
+const POLICY: Record<ResourceKey, LinhaRecurso> = {
+  CHAMADO_CRIAR: {
+    label: "Chamado — abrir",
+    rota: { metodo: "POST", caminho: "/tickets" },
+    perfis: { USUARIO: "proprios", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
+  },
   CHAMADO_VER: {
-    USUARIO: ["proprios"],
-    BACKOFFICE: ["organizacao"],
-    TECNICO: ["atribuido_e_setor", "setores"],
-    ADMINISTRADOR: ["todos"],
+    label: "Chamado — ver / listar",
+    rota: { metodo: "GET", caminho: "/tickets, /tickets/:id" },
+    perfis: { USUARIO: "proprios", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
   },
   CHAMADO_COMENTAR: {
-    USUARIO: ["proprios"],
-    BACKOFFICE: ["todos"],
-    TECNICO: ["atribuido_e_setor", "setores"],
-    ADMINISTRADOR: ["todos"],
+    label: "Chamado — mensagens",
+    rota: { metodo: "GET/POST", caminho: "/tickets/:id/mensagens" },
+    perfis: { USUARIO: "proprios", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
   },
   CHAMADO_ANEXAR: {
-    USUARIO: ["proprios"],
-    BACKOFFICE: ["todos"],
-    TECNICO: ["atribuido_e_setor", "setores"],
-    ADMINISTRADOR: ["todos"],
+    label: "Chamado — anexos",
+    rota: { metodo: "GET/POST", caminho: "/tickets/:id/anexos" },
+    perfis: { USUARIO: "proprios", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
   },
-  CHAMADO_ALTERAR_STATUS: {
-    BACKOFFICE: ["todos"],
-    TECNICO: ["para_si_ou_time"],
-    ADMINISTRADOR: ["qualquer"],
+  CHAMADO_EDITAR: {
+    label: "Chamado — atualizar (status, campos)",
+    rota: { metodo: "PATCH", caminho: "/tickets/:id" },
+    perfis: { USUARIO: "proprios", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
   },
-  CHAMADO_ENCERRAR: {
-    USUARIO: ["resolvido_para_encerrado"],
+  CHAMADO_REMOVER: {
+    label: "Chamado — remover (soft delete)",
+    rota: { metodo: "DELETE", caminho: "/tickets/:id" },
+    perfis: { USUARIO: "proprios", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
   },
-  CHAMADO_HISTORICO_VER: {
-    USUARIO: ["proprios"],
-    BACKOFFICE: ["todos"],
-    TECNICO: ["setores"],
-    ADMINISTRADOR: ["todos"],
+  CATALOGO_LISTAR: {
+    label: "Catálogo de serviços — listar",
+    rota: { metodo: "GET", caminho: "/catalogo" },
+    perfis: { USUARIO: "todos", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
   },
-  CATALOGO_EDITAR: {
-    BACKOFFICE: ["operacional"],
-    TECNICO: ["setores"],
-    ADMINISTRADOR: ["todos"],
+  USUARIOS_LISTAR: {
+    label: "Usuários — listar / ver",
+    rota: { metodo: "GET", caminho: "/usuarios" },
+    perfis: { BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
+  },
+  USUARIOS_CRIAR: {
+    label: "Usuários — criar",
+    rota: { metodo: "POST", caminho: "/usuarios" },
+    perfis: { ADMINISTRADOR: "todos" },
+  },
+  USUARIOS_EDITAR: {
+    label: "Usuários — editar",
+    rota: { metodo: "PATCH", caminho: "/usuarios/:id" },
+    perfis: { USUARIO: "proprios", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
+  },
+  USUARIOS_REMOVER: {
+    label: "Usuários — remover",
+    rota: { metodo: "DELETE", caminho: "/usuarios/:id" },
+    perfis: { ADMINISTRADOR: "todos" },
+  },
+  SETORES_GERENCIAR: {
+    label: "Setores — criar / editar / remover",
+    rota: { metodo: "POST/PATCH/DELETE", caminho: "/admin/setores" },
+    perfis: { ADMINISTRADOR: "todos" },
+  },
+  VINCULAR_USUARIO_SETOR: {
+    label: "Vincular usuário ⇄ setor",
+    rota: { metodo: "POST/PATCH/DELETE", caminho: "/admin/usuarios-setores" },
+    perfis: { TECNICO: "todos", ADMINISTRADOR: "todos" },
+  },
+  PAPEIS_GERENCIAR: {
+    label: "Papéis (catálogo) — gerenciar",
+    rota: { metodo: "POST/PATCH/DELETE", caminho: "/admin/papeis" },
+    perfis: { ADMINISTRADOR: "todos" },
+  },
+  COMUNICACOES_GERENCIAR: {
+    label: "Comunicações (templates) — gerenciar",
+    rota: { metodo: "GET/PUT/POST", caminho: "/admin/comunicacoes" },
+    perfis: { ADMINISTRADOR: "todos" },
   },
   AUDITORIA_VISUALIZAR: {
-    BACKOFFICE: ["operacional"],
-    TECNICO: ["setores"],
-    ADMINISTRADOR: ["gerencial"],
+    label: "Auditoria — visualizar",
+    rota: { metodo: "GET", caminho: "/auditoria" },
+    perfis: { ADMINISTRADOR: "todos" },
   },
   RELATORIOS: {
-    TECNICO: ["setores"],
+    label: "Relatórios / estatísticas",
+    rota: { metodo: "GET", caminho: "/tickets/stats" },
+    // Rota exige apenas autenticação (sem authorize de papel).
+    perfis: { USUARIO: "todos", BACKOFFICE: "todos", TECNICO: "todos", ADMINISTRADOR: "todos" },
   },
 };
 
+const ESCOPO_LABEL = { todos: "todos", proprios: "próprios" } as const;
 
-/* ===================== Página ===================== */
+/* ===================== Página (somente leitura) ===================== */
 export default function ConfiguracoesPermissoesPage() {
-  const [matrix, setMatrix] = useState<Matrix>(() => defaultMatrix());
-  const [filter, setFilter] = useState(""); // busca por recurso
-  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [filter, setFilter] = useState("");
 
   const rows = useMemo(() => {
-    const all = Object.keys(RESOURCE_LABEL) as ResourceKey[];
-    return all.filter((k) =>
-      !filter || RESOURCE_LABEL[k].toLowerCase().includes(filter.toLowerCase())
+    const all = Object.keys(POLICY) as ResourceKey[];
+    const q = filter.trim().toLowerCase();
+    if (!q) return all;
+    return all.filter(
+      (k) =>
+        POLICY[k].label.toLowerCase().includes(q) ||
+        POLICY[k].rota.caminho.toLowerCase().includes(q),
     );
   }, [filter]);
-
-  function toggle(role: Role, key: ResourceKey) {
-    setMatrix((prev) => {
-      const next = structuredClone(prev);
-      const cell = next[key][role];
-      cell.allow = !cell.allow;
-      // se desabilitar, limpa escopo; se habilitar e houver lista restrita, pega o primeiro
-      if (!cell.allow) {
-        delete cell.scope;
-      } else if (!cell.scope) {
-        const opts = ROW_ROLE_SCOPES[key]?.[role];
-        if (opts?.length) cell.scope = opts[0];
-      }
-      return next;
-    });
-  }
-
-  function setScope(role: Role, key: ResourceKey, scope: Scope) {
-    setMatrix((prev) => {
-      const next = structuredClone(prev);
-      next[key][role].scope = scope;
-      return next;
-    });
-  }
-
-  function exportJSON() {
-    const blob = new Blob([JSON.stringify(matrix, null, 2)], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a"); a.href = url; a.download = "permissoes_roles.json"; a.click();
-    URL.revokeObjectURL(url);
-  }
-
-  function importJSON(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]; if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      try {
-        const data = JSON.parse(String(reader.result)) as Matrix;
-        // validação simples
-        if (!data || typeof data !== "object") throw new Error("inválido");
-        setMatrix(data);
-      } catch {
-        alert("JSON inválido.");
-      }
-    };
-    reader.readAsText(file);
-    e.target.value = "";
-  }
-
-  function resetDefaults() {
-    if (confirm("Restaurar a matriz padrão?")) {
-      setMatrix(defaultMatrix());
-    }
-  }
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="rounded-xl border border-[var(--border)] bg-card p-4 flex items-center justify-between">
+      <div className="rounded-xl border border-[var(--border)] bg-card p-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <div className="size-9 rounded-lg grid place-items-center bg-primary text-primary-foreground">
             <Shield className="size-5" />
           </div>
           <div>
-            <h1 className="font-grotesk text-xl font-semibold">Configurações — Permissões de Papéis</h1>
+            <h1 className="font-grotesk text-xl font-semibold">Permissões de acesso</h1>
             <p className="text-sm text-muted-foreground">
-              Defina o que cada papel pode fazer e em qual escopo (próprios, setor, organização, etc.).
+              Quem pode fazer o quê, por papel — conforme aplicado pelo backend.
             </p>
           </div>
         </div>
+        <span className="inline-flex items-center gap-1.5 self-start rounded-full border border-[var(--border)] bg-[var(--muted)] px-3 py-1 text-xs text-muted-foreground">
+          <Lock className="size-3.5" /> Somente leitura
+        </span>
+      </div>
 
-        <div className="flex items-center gap-2">
-          <button
-            onClick={exportJSON}
-            className="inline-flex items-center gap-2 h-9 px-3 rounded-md border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
-          >
-            <Download className="size-4" /> Exportar JSON
-          </button>
-          <div>
-            <input ref={fileRef} type="file" accept="application/json" className="hidden" onChange={importJSON} />
-            <button
-              onClick={() => fileRef.current?.click()}
-              className="inline-flex items-center gap-2 h-9 px-3 rounded-md border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
-            >
-              <Upload className="size-4" /> Importar
-            </button>
-          </div>
-          <button
-            onClick={resetDefaults}
-            className="inline-flex items-center gap-2 h-9 px-3 rounded-md border border-[var(--border)] hover:bg-[var(--muted)] text-sm"
-          >
-            <RotateCcw className="size-4" /> Restaurar padrão
-          </button>
+      {/* Aviso */}
+      <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-sm">
+        <div className="flex items-start gap-2">
+          <Info className="size-4 mt-[2px] text-amber-600 shrink-0" />
+          <p className="text-muted-foreground">
+            Esta tela <b>reflete</b> a política de acesso que o servidor já aplica em cada rota
+            (papel + posse do recurso). Ela <b>não é configurável por aqui</b>: as regras estão no
+            código do backend. <b>Próprios</b> = apenas os registros do próprio usuário (ex.:
+            chamados criados por ele); <b>todos</b> = sem restrição de posse.
+          </p>
         </div>
       </div>
 
       {/* Filtro */}
       <div className="rounded-xl border border-[var(--border)] bg-card p-3">
         <input
-          placeholder="Filtrar por recurso/ação (ex.: chamado, catálogo...)"
-          className="w-full h-10 rounded-lg border border-[var(--border)] bg-input px-3"
+          placeholder="Filtrar por recurso ou rota (ex.: chamado, /usuarios...)"
+          className="w-full h-10 rounded-lg border border-[var(--border)] bg-input px-3 focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
         />
       </div>
 
       {/* Matriz */}
-      <div className="rounded-xl border border-[var(--border)] bg-card overflow-auto">
+      <div className="rounded-xl border border-[var(--border)] bg-card overflow-x-auto">
         <table className="min-w-full text-sm">
           <thead className="bg-[var(--muted)]">
             <tr>
-              <th className="text-left font-semibold px-4 py-3 w-[360px]">Recurso / Ação</th>
-              {(["USUARIO","BACKOFFICE","TECNICO","ADMINISTRADOR"] as Role[]).map((r) => (
-                <th key={r} className="text-left font-semibold px-4 py-3">{ROLE_LABEL[r]}</th>
+              <th className="text-left font-semibold px-4 py-3 w-[300px]">Recurso / Ação</th>
+              {ROLES.map((r) => (
+                <th key={r} className="text-left font-semibold px-4 py-3 whitespace-nowrap">{ROLE_LABEL[r]}</th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {rows.map((rk) => (
-              <tr key={rk} className="border-t border-[var(--border)] align-top">
-                <td className="px-4 py-3 font-medium">{RESOURCE_LABEL[rk]}</td>
-
-                {(["USUARIO","BACKOFFICE","TECNICO","ADMINISTRADOR"] as Role[]).map((role) => {
-                  const cell = matrix[rk][role];
-                  const scopeOptions = ROW_ROLE_SCOPES[rk]?.[role];
-
-                  return (
-                    <td key={role} className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          onClick={() => toggle(role, rk)}
-                          className={cx(
-                            "inline-flex items-center justify-center size-7 rounded-md border",
-                            cell.allow
-                              ? "bg-primary text-primary-foreground border-transparent"
-                              : "hover:bg-[var(--muted)]"
-                          )}
-                          title={cell.allow ? "Permitido" : "Negado"}
-                        >
-                          {cell.allow ? <Check className="size-4" /> : <X className="size-4" />}
-                        </button>
-
-                        {/* Scope quando aplicável e permitido */}
-                        {cell.allow && scopeOptions?.length ? (
-                          <select
-                            className="h-8 rounded-md border border-[var(--border)] bg-background px-2"
-                            value={cell.scope ?? scopeOptions[0]}
-                            onChange={(e) => setScope(role, rk, e.target.value as Scope)}
+            {rows.map((rk) => {
+              const linha = POLICY[rk];
+              return (
+                <tr key={rk} className="border-t border-[var(--border)] align-top">
+                  <td className="px-4 py-3">
+                    <div className="font-medium">{linha.label}</div>
+                    <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">
+                      {linha.rota.metodo} {linha.rota.caminho}
+                    </div>
+                  </td>
+                  {ROLES.map((role) => {
+                    const escopo = linha.perfis[role];
+                    const permitido = !!escopo;
+                    return (
+                      <td key={role} className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={
+                              permitido
+                                ? "inline-flex items-center justify-center size-7 rounded-md bg-[var(--success)]/15 text-[var(--success)]"
+                                : "inline-flex items-center justify-center size-7 rounded-md bg-[var(--muted)] text-muted-foreground"
+                            }
+                            title={permitido ? "Permitido" : "Negado"}
                           >
-                            {scopeOptions.map((s) => (
-                              <option key={s} value={s}>{SCOPE_LABEL[s]}</option>
-                            ))}
-                          </select>
-                        ) : cell.allow && cell.scope ? (
-                          <span className="text-xs rounded-md border border-[var(--border)] bg-background px-2 py-0.5">
-                            {SCOPE_LABEL[cell.scope]}
+                            {permitido ? <Check className="size-4" /> : <X className="size-4" />}
                           </span>
-                        ) : null}
-                      </div>
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
+                          {permitido && (
+                            <span className="text-xs rounded-md border border-[var(--border)] bg-background px-2 py-0.5">
+                              {ESCOPO_LABEL[escopo]}
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
 
-      {/* Legenda / Dicas */}
+      {/* Nota */}
       <div className="rounded-xl border border-[var(--border)] bg-card p-4 text-sm">
         <div className="flex items-start gap-2">
-          <Info className="size-4 mt-[2px]" />
-          <div className="space-y-2">
-            <p className="text-muted-foreground">
-              Esta matriz define as capabilities da aplicação. Em tempo de execução, recomenda-se
-              validar as regras combinando o <b>Papel do usuário</b>, suas relações em <code>UsuarioSetor</code> e o
-              ownership do recurso (por exemplo, <code>Chamado.criadoPorId</code> para “próprios”, ou <code>setorId</code> para “setor(es)”).
+          <Info className="size-4 mt-[2px] shrink-0" />
+          <div className="space-y-1.5 text-muted-foreground">
+            <p>
+              Para alunos (papel <b>Usuário</b>), o backend restringe as ações de chamado aos
+              próprios registros (verificação de posse por <code>criadoPorId</code>), e o
+              <code> PATCH /usuarios/:id</code> permite editar apenas o próprio cadastro, sem os
+              campos privilegiados (papel, ativo, senha).
             </p>
-            <ul className="list-disc pl-4 text-muted-foreground">
-              <li><b>atribuídos + setor(es)</b>: o usuário vê/atua nos chamados que estão atribuídos a ele(a) <i>ou</i> pertencem ao(s) setor(es) dele(a).</li>
-              <li><b>para si/time</b>: mudanças de status que afetem apenas chamados sob responsabilidade do próprio técnico ou time imediato.</li>
-              <li><b>operacional/gerencial</b>: filtros/escopos de dados mais restritos/abrangentes para Backoffice/Administrador.</li>
-              <li><b>Aluno encerrar</b>: permitido apenas quando o status vai de <code>RESOLVIDO → ENCERRADO</code>.</li>
-            </ul>
+            <p>
+              <b>Relatórios</b> hoje exige apenas autenticação (a rota <code>/tickets/stats</code>{" "}
+              não filtra por papel) — considere restringir a equipe se as estatísticas forem sensíveis.
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Remoção de mocks

### 1. Reset de senha do aluno (era stub)
`/admin/alunos/[id]` tinha `onResetSenha` = `toast("...(stub)")`. Agora dispara `POST /auth/esqueci-senha` com o e-mail do aluno e envia de fato o link (mensagem de erro via `extractApiError`). Mesma correção já aplicada ao detalhe de funcionário.

### 2. Configurações — matriz de permissões (era 100% mock)
A tela era uma matriz **editável em memória**, com Exportar/Importar/Restaurar que **não persistiam em lugar nenhum** e descreviam permissões finas que o backend não aplica. Como a autorização do backend é por rota (`authorize([...])` + posse do aluno), uma matriz configurável não teria efeito real.

Reescrita como **visão somente-leitura** que reflete a política **realmente aplicada** pelo backend:
- Uma linha por recurso/ação, com o **método + rota** correspondente.
- Marcação permitido/negado por papel, com escopo **próprios**/**todos**.
- Removidos os controles que fingiam salvar; banner "Somente leitura" e nota explicando o escopo do aluno.
- Sinaliza um achado real: `/tickets/stats` hoje exige apenas autenticação (não filtra por papel).

## Verificação
`next build --turbopack` passa; typecheck ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A ação de **resetar senha** no detalhe do aluno agora envia de fato o link de redefinição por e-mail e mostra mensagens de sucesso ou erro.

* **Bug Fixes**
  * A tela de **configurações** foi atualizada para exibir a política de permissões em modo **somente leitura**, com indicação clara de acesso permitido, escopo e busca por recurso.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->