### PR TITLE
chore(quick-wins): padroniza apiFetch e skeletons nas listas principais

### DIFF
--- a/app/(dashboard)/admin/_components/ImportAlunos.tsx
+++ b/app/(dashboard)/admin/_components/ImportAlunos.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import { X, Info } from "lucide-react";
 import { toast } from "sonner";
+import { apiFetch } from "../../../../utils/api";
 
 type ResultRow = {
   idx: number;
@@ -155,15 +156,6 @@ export default function ImportAlunos({
     setRunning(true);
     setFinished(false);
 
-    const token =
-      (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
-
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    };
-
     const clone = [...rows];
 
     for (let i = 0; i < clone.length; i++) {
@@ -204,9 +196,8 @@ export default function ImportAlunos({
       if (r.anoSemestreIngresso?.trim()) payload.anoSemestreIngresso = r.anoSemestreIngresso.trim();
 
       try {
-        const resp = await fetch(`${API_URL}/usuarios`, {
+        const resp = await apiFetch(`${API_URL}/usuarios`, {
           method: "POST",
-          headers,
           body: JSON.stringify(payload),
         });
 

--- a/app/(dashboard)/admin/alunos/[id]/page.tsx
+++ b/app/(dashboard)/admin/alunos/[id]/page.tsx
@@ -135,20 +135,12 @@ export default function PageAlunoDetalhe() {
     async function load() {
       try {
         setLoading(true);
-        const token =
-          (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
 
-        const uRes = await fetch(`${API_URL}/usuarios/${id}`, {
-          headers: { Authorization: token ? `Bearer ${token}` : "" },
-          cache: "no-store",
-        });
+        const uRes = await apiFetch(`${API_URL}/usuarios/${id}`, { cache: "no-store" });
         if (!uRes.ok) throw new Error("Falha ao buscar usuário");
         const u: Usuario = await uRes.json();
 
-        const cRes = await fetch(`${API_URL}/tickets?criadoPorId=${u.id}`, {
-          headers: { Authorization: token ? `Bearer ${token}` : "" },
-          cache: "no-store",
-        });
+        const cRes = await apiFetch(`${API_URL}/tickets?criadoPorId=${u.id}`, { cache: "no-store" });
         if (!cRes.ok) throw new Error("Falha ao buscar tickets");
         const json = await cRes.json();
         let cs: Chamado[] = [];

--- a/app/(dashboard)/admin/alunos/page.tsx
+++ b/app/(dashboard)/admin/alunos/page.tsx
@@ -18,6 +18,8 @@ import FormAlunoCreate from "./../_components/FormAlunoCreate";
 import ImportAlunos from "./../_components/ImportAlunos";
 import ConfirmDialog from "../../../components/ui/ConfirmDialog";
 import { toast } from "sonner";
+import { apiFetch } from "../../../../utils/api";
+import { Skeleton } from "../../../components/ui/Skeleton";
 
 import { cx } from '../../../../utils/cx'
 
@@ -90,12 +92,6 @@ export default function AdminAlunosPage() {
       setLoading(true);
       setError(null);
 
-      const token =
-        (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
-
-      const headers: Record<string, string> = { Accept: "application/json" };
-      if (token) headers.Authorization = `Bearer ${token}`;
-
       const qs = new URLSearchParams();
       qs.set("papel", "USUARIO");
       if (q) qs.set("q", q);
@@ -103,7 +99,7 @@ export default function AdminAlunosPage() {
       qs.set("page", String(page));
       qs.set("perPage", String(perPage));
 
-      const res = await fetch(`${API_URL}/usuarios?${qs}`, { headers, cache: "no-store" });
+      const res = await apiFetch(`${API_URL}/usuarios?${qs}`, { cache: "no-store" });
       if (!res.ok) {
         const text = await res.text().catch(() => "");
         throw new Error(text || `Falha ao buscar alunos (${res.status})`);
@@ -255,14 +251,9 @@ export default function AdminAlunosPage() {
   async function doDeleteSelected() {
     try {
       setDeleting(true);
-      const token =
-        (typeof window !== "undefined" && localStorage.getItem("accessToken")) || "";
-      const headers: Record<string, string> = { Accept: "application/json" };
-      if (token) headers.Authorization = `Bearer ${token}`;
-
       const results = await Promise.allSettled(
         Array.from(selectedIds).map((id) =>
-          fetch(`${API_URL}/usuarios/${id}`, { method: "DELETE", headers }),
+          apiFetch(`${API_URL}/usuarios/${id}`, { method: "DELETE" }),
         ),
       );
 
@@ -423,13 +414,13 @@ export default function AdminAlunosPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {loading && (
-                    <tr>
-                      <td colSpan={7} className="px-4 py-6 text-center text-muted-foreground">
-                        Carregando...
-                      </td>
+                  {loading && Array.from({ length: 6 }).map((_, r) => (
+                    <tr key={`sk-${r}`} className="border-t border-[var(--border)]">
+                      {Array.from({ length: 7 }).map((_, c) => (
+                        <td key={c} className="px-4 py-3"><Skeleton className="h-3.5 w-full" /></td>
+                      ))}
                     </tr>
-                  )}
+                  ))}
 
                   {!loading && visibleRows.map((a) => (
                     <tr key={a.id} className="border-t border-[var(--border)]">

--- a/app/(dashboard)/admin/chamados/page.tsx
+++ b/app/(dashboard)/admin/chamados/page.tsx
@@ -13,6 +13,7 @@ import TicketStatusBadge from "../../../components/shared/TicketStatusBadge";
 import PriorityDot from "../../../components/shared/PriorityDot";
 import NivelBadge from "../../../components/shared/NivelBadge";
 import SetorChip from "../../../components/shared/SetorChip";
+import { SkeletonTable } from "../../../components/ui/Skeleton";
 import type { Chamado, Nivel, PageResponse, Prioridade, Status } from "../../../../utils/types";
 
 /* ===== Tipos ===== */
@@ -248,9 +249,7 @@ export default function AdminChamadosPage() {
 
       {/* Conteúdo */}
       {loading ? (
-        <div className="rounded-xl border border-[var(--border)] bg-card p-10 text-center text-muted-foreground">
-          Carregando chamados...
-        </div>
+        <SkeletonTable rows={6} cols={5} />
       ) : error ? (
         <div className="rounded-xl border border-[var(--border)] bg-card p-10 text-center text-destructive">
           Falha ao carregar: {error}

--- a/app/(dashboard)/admin/funcionarios/page.tsx
+++ b/app/(dashboard)/admin/funcionarios/page.tsx
@@ -7,6 +7,7 @@ import {
   Mail, BadgeCheck, Building2, User as UserIcon
 } from "lucide-react";
 import { apiFetch } from "../../../../utils/api";
+import { Skeleton } from "../../../components/ui/Skeleton";
 import { cx } from '../../../../utils/cx';
 
 /* ========= Tipos ========= */
@@ -259,9 +260,13 @@ export default function AdminFuncionariosPage() {
               </tr>
             </thead>
             <tbody>
-              {loading && (
-                <tr><td colSpan={6} className="px-4 py-6 text-center text-muted-foreground">Carregando...</td></tr>
-              )}
+              {loading && Array.from({ length: 6 }).map((_, r) => (
+                <tr key={`sk-${r}`} className="border-t border-[var(--border)]">
+                  {Array.from({ length: 6 }).map((_, c) => (
+                    <td key={c} className="px-4 py-3"><Skeleton className="h-3.5 w-full" /></td>
+                  ))}
+                </tr>
+              ))}
               {!loading && visibleRows.map((f) => (
                 <tr key={f.id} className="border-t border-[var(--border)]">
                   <td className="px-4 py-3">

--- a/app/(dashboard)/aluno/home/page.tsx
+++ b/app/(dashboard)/aluno/home/page.tsx
@@ -10,6 +10,7 @@ import KpiCard from "../../../components/shared/KpiCard";
 import { SkeletonKpi, SkeletonTable } from "../../../components/ui/Skeleton";
 import EmptyState from "../../../components/ui/EmptyState";
 import Button from "../../../components/ui/Button";
+import { apiFetch } from "../../../../utils/api";
 
 type Status = "ABERTO" | "EM_ATENDIMENTO" | "AGUARDANDO_USUARIO" | "RESOLVIDO" | "ENCERRADO";
 type Prioridade = "BAIXA" | "MEDIA" | "ALTA" | "URGENTE";
@@ -33,19 +34,15 @@ export default function AlunoHomePage() {
     async function fetchChamados() {
       try {
         setLoading(true);
-        const token = localStorage.getItem("accessToken");
-        if (!token) throw new Error("Token não encontrado");
 
-        const base = `${process.env.NEXT_PUBLIC_API_BASE_URL}/tickets?include=setor`;
+        const base = `${process.env.NEXT_PUBLIC_API_BASE_URL ?? ""}/tickets?include=setor`;
         const pageSize = 100;
         let page = 1;
         let total = 0;
         const all: Chamado[] = [];
 
         while (true) {
-          const res = await fetch(`${base}&page=${page}&pageSize=${pageSize}`, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
+          const res = await apiFetch(`${base}&page=${page}&pageSize=${pageSize}`, { cache: "no-store" });
           if (!res.ok) throw new Error("Erro ao buscar solicitações");
           const data = await res.json();
           if (page === 1) total = data.total ?? 0;


### PR DESCRIPTION
## Ganhos rápidos do roadmap (frontend)

### #1 — Padronizar `apiFetch`
Telas autenticadas que usavam `fetch` cru com `Authorization` manual passam a usar `apiFetch` — que injeta o token e **renova automaticamente no 401**. Migradas: `aluno/home`, `admin/alunos` (lista + exclusão em massa), `admin/alunos/[id]` e `ImportAlunos`.

As páginas **públicas** de auth (`login`, `esqueci-senha`, `reset-senha`, `primeiro-acesso`) seguem com `fetch` cru de propósito — são pré-login, sem token para renovar.

### #5 — Skeletons nas listas principais
`admin/chamados`, `admin/alunos` e `admin/funcionarios` trocam o texto "Carregando…" por linhas de skeleton (`SkeletonTable` / `Skeleton`), alinhado ao que a home do aluno já fazia. Loading mais suave e sem salto de layout.

## Verificação
`next build --turbopack` passa; typecheck ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7D3tnefEbqhK58wj5vtS9)_